### PR TITLE
Add ingress rule for gql health check

### DIFF
--- a/charts/flash/Chart.yaml
+++ b/charts/flash/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2 # https://helm.sh/docs/topics/charts/#the-apiversion-field
 name: flash
 description: A Helm chart for the Flash application backend
 type: application
-version: 0.0.36-test3
+version: 0.0.36
 appVersion: 0.6.4
 dependencies:
   - name: redis

--- a/charts/flash/Chart.yaml
+++ b/charts/flash/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2 # https://helm.sh/docs/topics/charts/#the-apiversion-field
 name: flash
 description: A Helm chart for the Flash application backend
 type: application
-version: 0.0.35
+version: 0.0.36-test
 appVersion: 0.6.4
 dependencies:
   - name: redis

--- a/charts/flash/Chart.yaml
+++ b/charts/flash/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2 # https://helm.sh/docs/topics/charts/#the-apiversion-field
 name: flash
 description: A Helm chart for the Flash application backend
 type: application
-version: 0.0.36-test
+version: 0.0.36-test2
 appVersion: 0.6.4
 dependencies:
   - name: redis

--- a/charts/flash/Chart.yaml
+++ b/charts/flash/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2 # https://helm.sh/docs/topics/charts/#the-apiversion-field
 name: flash
 description: A Helm chart for the Flash application backend
 type: application
-version: 0.0.36-test2
+version: 0.0.36-test3
 appVersion: 0.6.4
 dependencies:
   - name: redis

--- a/charts/flash/templates/api-healthz-ingress.yaml
+++ b/charts/flash/templates/api-healthz-ingress.yaml
@@ -2,7 +2,7 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ template "galoy.api.fullname" . }}
+  name: {{ template "galoy.api.fullname" . }}-healthz
   labels:
     app: {{ template "galoy.api.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
@@ -21,16 +21,6 @@ metadata:
     nginx.ingress.kubernetes.io/cors-allow-methods: POST
     nginx.ingress.kubernetes.io/cors-allow-origin: {{ .Values.galoy.api.flashPay.hostname }}
     nginx.ingress.kubernetes.io/enable-cors: "true"
-    nginx.ingress.kubernetes.io/auth-url: "http://flash-oathkeeper-api.{{ .Release.Namespace }}.svc.cluster.local:4456/decisions"
-    nginx.ingress.kubernetes.io/auth-method: GET
-    nginx.ingress.kubernetes.io/auth-response-headers: "Authorization, Set-Cookie"
-    nginx.ingress.kubernetes.io/auth-forward-cookie: "*"
-    nginx.ingress.kubernetes.io/auth-snippet: |
-      proxy_set_header X-Original-URL $request_uri;
-      proxy_set_header X-Forwarded-Method $request_method;
-      proxy_set_header X-Forwarded-Proto $scheme;
-      proxy_set_header X-Forwarded-Host $host;
-      proxy_set_header X-Forwarded-Uri $request_uri;
     {{- with .Values.galoy.api.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -47,22 +37,12 @@ spec:
     - host: {{ . }}
       http:
         paths:
-          {{- if $.Values.galoy.api.ingress.extraPaths }}
-          {{- toYaml $.Values.galoy.api.ingress.extraPaths | nindent 10 }}
-          {{- end }}
-          - pathType: ImplementationSpecific
-            path: /graphql
-            backend:
-              service:
-                name: "{{ $.Release.Name }}-router"
-                port:
-                  number: {{ $.Values.galoy.router.port }}
-          - pathType: ImplementationSpecific
-            path: /
-            backend:
-              service:
-                name: {{ template "galoy.api.fullname" $ }}
-                port:
-                  number: {{ $.Values.galoy.api.port }}
+        - pathType: ImplementationSpecific
+          path: /healthz
+          backend:
+            service:
+              name: {{ template "galoy.api.fullname" $ }}
+              port:
+                number: {{ $.Values.galoy.api.port }}
   {{- end -}}
 {{- end -}}

--- a/charts/flash/templates/api-ingress.yaml
+++ b/charts/flash/templates/api-ingress.yaml
@@ -65,7 +65,9 @@ spec:
                 port:
                   number: {{ $.Values.galoy.api.port }}
   {{- end -}}
+{{- end -}}
 ---
+{{- if .Values.galoy.api.ingress.enabled -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/charts/flash/templates/api-ingress.yaml
+++ b/charts/flash/templates/api-ingress.yaml
@@ -65,4 +65,51 @@ spec:
                 port:
                   number: {{ $.Values.galoy.api.port }}
   {{- end -}}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ template "galoy.api.fullname" . }}-healthz
+  labels:
+    app: {{ template "galoy.api.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    cert-manager.io/cluster-issuer: {{ .Values.galoy.api.ingress.clusterIssuer }}
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600" # 1 hour
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600" # 1 hour
+    nginx.ingress.kubernetes.io/proxy-connect-timeout: "1s"
+    nginx.ingress.kubernetes.io/proxy-next-upstream: "error timeout"
+    nginx.ingress.kubernetes.io/proxy-next-upstream-tries: "3"
+    nginx.ingress.kubernetes.io/limit-rpm: "60"
+    nginx.ingress.kubernetes.io/limit-burst-multiplier: "40"
+    nginx.ingress.kubernetes.io/limit-connections: "80"
+    nginx.ingress.kubernetes.io/cors-allow-methods: POST
+    nginx.ingress.kubernetes.io/cors-allow-origin: {{ .Values.galoy.api.flashPay.hostname }}
+    nginx.ingress.kubernetes.io/enable-cors: "true"
+    {{- with .Values.galoy.api.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  ingressClassName: nginx
+  tls:
+    {{- range .Values.galoy.api.ingress.hosts }}
+    - hosts:
+      - {{ . }}
+      secretName: {{ printf "%s-tls" . }}
+    {{- end }}
+  rules:
+  {{- range .Values.galoy.api.ingress.hosts }}
+    - host: {{ . }}
+      http:
+        paths:
+        - pathType: ImplementationSpecific
+          path: /healthz
+          backend:
+            service:
+              name: {{ template "galoy.api.fullname" $ }}
+              port:
+                number: {{ $.Values.galoy.api.port }}
+  {{- end -}}
 {{- end -}}


### PR DESCRIPTION
This is created as a separate ingress resource in order to apply a different set of annotations that does not include oathkeeper authorization. 