### PR TITLE
chore(deps): bump-flash-image-

### DIFF
--- a/charts/flash/Chart.yaml
+++ b/charts/flash/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2 # https://helm.sh/docs/topics/charts/#the-apiversion-field
 name: flash
 description: A Helm chart for the Flash application backend
 type: application
-version: 0.0.39
+version: 0.0.40
 appVersion: 0.6.10
 dependencies:
   - name: redis

--- a/charts/flash/Chart.yaml
+++ b/charts/flash/Chart.yaml
@@ -3,7 +3,7 @@ name: flash
 description: A Helm chart for the Flash application backend
 type: application
 version: 0.0.39
-appVersion: 0.6.9
+appVersion: 0.6.10
 dependencies:
   - name: redis
     repository: https://charts.bitnami.com/bitnami

--- a/charts/flash/values.yaml
+++ b/charts/flash/values.yaml
@@ -21,16 +21,16 @@ galoy:
       repository: lnflash/flash-app:edge
       imagePullPolicy: Always
       # digests managed by flash-app pipeline in concourse
-      digest: sha256:0c1718d0fa23446433ddbb0bc01c6e77c47101f91f798a27c42b18aca5f9ff4d
-      git_ref: "d3d9727"
+      digest: sha256:43f5c185dae08fdc4b2b12fc69e89daa355fbd1e18a8df668de088e8be780581
+      git_ref: "a1362fd"
     websocket:
       repository: docker.io/lnflash/galoy-app-websocket
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:3a2204f96012c6e40a87388431ea8c9ff21e30eae31579ac96519bda6b7e2c7b"
+      digest: "sha256:b2c0eede55c76f2460a037ab46e51cc5e104b446b2772dbda1001dbaf2b7db19"
     mongodbMigrate:
       repository: docker.io/lnflash/galoy-app-migrate
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:f2d5b9d68ebb84bb58e0b1a016af4dac9e411a1ef0e50ea154da6ea640f9c7f4"
+      digest: "sha256:9c4589e1c922f9fc234e0a5e93dfcc1aaf01d3ed572090400b18982e7ca55b3a"
     mongoBackup:
       repository: us.gcr.io/galoy-org/mongo-backup
       # Currently using Galoy's images. To make changes, see /images & /ci in this repo


### PR DESCRIPTION
# Bump flash image

The flash image will be bumped to digest:
```
sha256:43f5c185dae08fdc4b2b12fc69e89daa355fbd1e18a8df668de088e8be780581
```

The mongodbMigrate image will be bumped to digest:
```
sha256:9c4589e1c922f9fc234e0a5e93dfcc1aaf01d3ed572090400b18982e7ca55b3a
```

The websocket image will be bumped to digest:
```
sha256:b2c0eede55c76f2460a037ab46e51cc5e104b446b2772dbda1001dbaf2b7db19
```

Code diff contained in this image:

https://github.com/lnflash/flash/compare/d3d9727...a1362fd
