### PR TITLE
chore(deps): bump-flash-image-

### DIFF
--- a/charts/flash/Chart.yaml
+++ b/charts/flash/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2 # https://helm.sh/docs/topics/charts/#the-apiversion-field
 name: flash
 description: A Helm chart for the Flash application backend
 type: application
-version: 0.0.48
+version: 0.0.49
 appVersion: 0.6.16
 dependencies:
   - name: redis

--- a/charts/flash/Chart.yaml
+++ b/charts/flash/Chart.yaml
@@ -3,7 +3,7 @@ name: flash
 description: A Helm chart for the Flash application backend
 type: application
 version: 0.0.48
-appVersion: 0.6.13
+appVersion: 0.6.16
 dependencies:
   - name: redis
     repository: https://charts.bitnami.com/bitnami

--- a/charts/flash/apollo-router/supergraph.graphql
+++ b/charts/flash/apollo-router/supergraph.graphql
@@ -439,6 +439,10 @@ type FeesInformation
   deposit: DepositFeesInformation!
 }
 
+"""(Positive) Cent amount (1/100 of a dollar) as a float"""
+scalar FractionalCentAmount
+  @join__type(graph: PUBLIC)
+
 """
 Provides global settings for the application which might have an impact for the user.
 """
@@ -786,7 +790,7 @@ input LnUsdInvoiceCreateInput
   @join__type(graph: PUBLIC)
 {
   """Amount in USD cents."""
-  amount: CentAmount!
+  amount: FractionalCentAmount!
 
   """Optional invoice expiration time in minutes."""
   expiresIn: Minutes
@@ -1066,7 +1070,7 @@ type npubByUsername
   npub: npub
 
   """Optional immutable user friendly identifier."""
-  username: Username @deprecated(reason: "will be moved to @Handle in Account and Wallet")
+  username: Username
 }
 
 """An address for an on-chain bitcoin destination"""

--- a/charts/flash/values.yaml
+++ b/charts/flash/values.yaml
@@ -21,16 +21,16 @@ galoy:
       repository: lnflash/flash-app:edge
       imagePullPolicy: Always
       # digests managed by flash-app pipeline in concourse
-      digest: sha256:81b436b327fbf13c7dd39bf7dbf9a19bae8dbab11d7433aba282260df4597865
-      git_ref: "0ddd06d"
+      digest: sha256:4c44236097bc9a546dd90430220ca4dd2ae0400ad26ac87cede315add9720261
+      git_ref: "ac3b62f"
     websocket:
       repository: docker.io/lnflash/galoy-app-websocket
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:bd81eefa12e5aa99454d641d3f04fbfdb82bd26d49f8c6a2d614a7065254d3ce"
+      digest: "sha256:46a153f9fe33dd102d5a7658840731ecb207608d1e0ef0c9f6582362962a80c1"
     mongodbMigrate:
       repository: docker.io/lnflash/galoy-app-migrate
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:d689ac5aabca24c83dc940ac71ce6d2588f5c353598b28a90b51cb22e84e28ba"
+      digest: "sha256:616f31f6c0b792d12d9fdaf6aea2316f221c83f03831145a350417b3ae67521f"
     mongoBackup:
       repository: us.gcr.io/galoy-org/mongo-backup
       # Currently using Galoy's images. To make changes, see /images & /ci in this repo


### PR DESCRIPTION
# Bump flash image

The flash image will be bumped to digest:
```
sha256:4c44236097bc9a546dd90430220ca4dd2ae0400ad26ac87cede315add9720261
```

The mongodbMigrate image will be bumped to digest:
```
sha256:616f31f6c0b792d12d9fdaf6aea2316f221c83f03831145a350417b3ae67521f
```

The websocket image will be bumped to digest:
```
sha256:46a153f9fe33dd102d5a7658840731ecb207608d1e0ef0c9f6582362962a80c1
```

Code diff contained in this image:

https://github.com/lnflash/flash/compare/0ddd06d...ac3b62f
