### PR TITLE
chore(deps): bump-flash-image-

### DIFF
--- a/charts/flash/Chart.yaml
+++ b/charts/flash/Chart.yaml
@@ -3,7 +3,7 @@ name: flash
 description: A Helm chart for the Flash application backend
 type: application
 version: 0.0.49
-appVersion: 0.6.16
+appVersion: 0.6.18
 dependencies:
   - name: redis
     repository: https://charts.bitnami.com/bitnami

--- a/charts/flash/apollo-router/supergraph.graphql
+++ b/charts/flash/apollo-router/supergraph.graphql
@@ -558,6 +558,19 @@ enum InvoicePaymentStatus
   PENDING @join__enumValue(graph: PUBLIC)
 }
 
+input IsFlashNpubInput
+  @join__type(graph: PUBLIC)
+{
+  npub: npub!
+}
+
+type IsFlashNpubPayload
+  @join__type(graph: PUBLIC)
+{
+  errors: [Error!]!
+  isFlashNpub: Boolean
+}
+
 scalar join__FieldSet
 
 enum join__Graph {
@@ -1348,6 +1361,7 @@ type Query
   businessMapMarkers: [MapMarker!]!
   currencyList: [Currency!]!
   globals: Globals
+  isFlashNpub(input: IsFlashNpubInput!): IsFlashNpubPayload
   lnInvoicePaymentStatus(input: LnInvoicePaymentStatusInput!): LnInvoicePaymentStatusPayload!
   me: User
   mobileVersions: [MobileVersions]

--- a/charts/flash/values.yaml
+++ b/charts/flash/values.yaml
@@ -21,16 +21,16 @@ galoy:
       repository: lnflash/flash-app:edge
       imagePullPolicy: Always
       # digests managed by flash-app pipeline in concourse
-      digest: sha256:4c44236097bc9a546dd90430220ca4dd2ae0400ad26ac87cede315add9720261
-      git_ref: "ac3b62f"
+      digest: sha256:40581c693f0033d054e644784385e917fddf957ee81cea9138307530fefeb2f9
+      git_ref: "7104133"
     websocket:
       repository: docker.io/lnflash/galoy-app-websocket
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:46a153f9fe33dd102d5a7658840731ecb207608d1e0ef0c9f6582362962a80c1"
+      digest: "sha256:ac19bc97bf98e018d87de38fe68dd9a18126d688fb2f87d8176f5bfacd582794"
     mongodbMigrate:
       repository: docker.io/lnflash/galoy-app-migrate
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:616f31f6c0b792d12d9fdaf6aea2316f221c83f03831145a350417b3ae67521f"
+      digest: "sha256:ec7bab9666b5225ecf9545cc837c6d5bba95373700c50e912bb015e87cf685e8"
     mongoBackup:
       repository: us.gcr.io/galoy-org/mongo-backup
       # Currently using Galoy's images. To make changes, see /images & /ci in this repo


### PR DESCRIPTION
# Bump flash image

The flash image will be bumped to digest:
```
sha256:74fb5f9ba823cf84890a6a8a906568b10e3e521f3f99bc86ebe849e04be4b35e
```

The mongodbMigrate image will be bumped to digest:
```
sha256:027b01fabcd197f997eb3682dbe12f73b6ba5267527ea947f1a22a84b1cbc220
```

The websocket image will be bumped to digest:
```
sha256:b50e0b99e1b3bacbc9dfc8aefda3b1b3fcce8b8b7ceef94776c75b6519ef6c83
```

Code diff contained in this image:

https://github.com/lnflash/flash/compare/ac3b62f...73ad0cd
