### PR TITLE
chore(deps): bump-flash-image-

### DIFF
--- a/charts/flash/Chart.yaml
+++ b/charts/flash/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2 # https://helm.sh/docs/topics/charts/#the-apiversion-field
 name: flash
 description: A Helm chart for the Flash application backend
 type: application
-version: 0.0.49
+version: 0.0.50
 appVersion: 0.6.19
 dependencies:
   - name: redis

--- a/charts/flash/Chart.yaml
+++ b/charts/flash/Chart.yaml
@@ -3,7 +3,7 @@ name: flash
 description: A Helm chart for the Flash application backend
 type: application
 version: 0.0.49
-appVersion: 0.6.16
+appVersion: 0.6.19
 dependencies:
   - name: redis
     repository: https://charts.bitnami.com/bitnami

--- a/charts/flash/apollo-router/supergraph.graphql
+++ b/charts/flash/apollo-router/supergraph.graphql
@@ -558,6 +558,19 @@ enum InvoicePaymentStatus
   PENDING @join__enumValue(graph: PUBLIC)
 }
 
+input IsFlashNpubInput
+  @join__type(graph: PUBLIC)
+{
+  npub: npub!
+}
+
+type IsFlashNpubPayload
+  @join__type(graph: PUBLIC)
+{
+  errors: [Error!]!
+  isFlashNpub: Boolean
+}
+
 scalar join__FieldSet
 
 enum join__Graph {
@@ -1348,6 +1361,7 @@ type Query
   businessMapMarkers: [MapMarker!]!
   currencyList: [Currency!]!
   globals: Globals
+  isFlashNpub(input: IsFlashNpubInput!): IsFlashNpubPayload
   lnInvoicePaymentStatus(input: LnInvoicePaymentStatusInput!): LnInvoicePaymentStatusPayload!
   me: User
   mobileVersions: [MobileVersions]

--- a/charts/flash/values.yaml
+++ b/charts/flash/values.yaml
@@ -21,16 +21,16 @@ galoy:
       repository: lnflash/flash-app:edge
       imagePullPolicy: Always
       # digests managed by flash-app pipeline in concourse
-      digest: sha256:4c44236097bc9a546dd90430220ca4dd2ae0400ad26ac87cede315add9720261
-      git_ref: "ac3b62f"
+      digest: sha256:bd26e6d43f5fb78bf73d1df0fc12887da3e5082ce0febdc1248dac22622218a1
+      git_ref: "1c6aecc"
     websocket:
       repository: docker.io/lnflash/galoy-app-websocket
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:46a153f9fe33dd102d5a7658840731ecb207608d1e0ef0c9f6582362962a80c1"
+      digest: "sha256:aa86ebeb9f4ea218a77093fadaef53ae84472d4cf6c65eeec713cb0f7959b77f"
     mongodbMigrate:
       repository: docker.io/lnflash/galoy-app-migrate
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:616f31f6c0b792d12d9fdaf6aea2316f221c83f03831145a350417b3ae67521f"
+      digest: "sha256:5ce37393650dcf6f7e21d1204e47263eb3ebf89cd43c857c84ea59f04ee80d22"
     mongoBackup:
       repository: us.gcr.io/galoy-org/mongo-backup
       # Currently using Galoy's images. To make changes, see /images & /ci in this repo


### PR DESCRIPTION
# Bump flash image

The flash image will be bumped to digest:
```
sha256:bd26e6d43f5fb78bf73d1df0fc12887da3e5082ce0febdc1248dac22622218a1
```

The mongodbMigrate image will be bumped to digest:
```
sha256:5ce37393650dcf6f7e21d1204e47263eb3ebf89cd43c857c84ea59f04ee80d22
```

The websocket image will be bumped to digest:
```
sha256:aa86ebeb9f4ea218a77093fadaef53ae84472d4cf6c65eeec713cb0f7959b77f
```

Code diff contained in this image:

https://github.com/lnflash/flash/compare/ac3b62f...1c6aecc
