### PR TITLE
chore(deps): bump-flash-image-

### DIFF
--- a/charts/flash/Chart.yaml
+++ b/charts/flash/Chart.yaml
@@ -3,7 +3,7 @@ name: flash
 description: A Helm chart for the Flash application backend
 type: application
 version: 0.0.50
-appVersion: 0.6.19
+appVersion: 0.6.20
 dependencies:
   - name: redis
     repository: https://charts.bitnami.com/bitnami

--- a/charts/flash/values.yaml
+++ b/charts/flash/values.yaml
@@ -21,16 +21,16 @@ galoy:
       repository: lnflash/flash-app:edge
       imagePullPolicy: Always
       # digests managed by flash-app pipeline in concourse
-      digest: sha256:bd26e6d43f5fb78bf73d1df0fc12887da3e5082ce0febdc1248dac22622218a1
-      git_ref: "1c6aecc"
+      digest: sha256:bda1e5ab39294a96e2eaab04c74ef7026c6e5709ee99bdf9e198df4f0555449a
+      git_ref: "f44647c"
     websocket:
       repository: docker.io/lnflash/galoy-app-websocket
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:aa86ebeb9f4ea218a77093fadaef53ae84472d4cf6c65eeec713cb0f7959b77f"
+      digest: "sha256:03adc92801da265635e762786c495b2740967e4a4f67a62c8ff916df47127e6e"
     mongodbMigrate:
       repository: docker.io/lnflash/galoy-app-migrate
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:5ce37393650dcf6f7e21d1204e47263eb3ebf89cd43c857c84ea59f04ee80d22"
+      digest: "sha256:09737b304e52cdd0c8d9df1c37fb3a7c7d1d0814e13592fe7124cb028f9fa90c"
     mongoBackup:
       repository: us.gcr.io/galoy-org/mongo-backup
       # Currently using Galoy's images. To make changes, see /images & /ci in this repo


### PR DESCRIPTION
# Bump flash image

The flash image will be bumped to digest:
```
sha256:bda1e5ab39294a96e2eaab04c74ef7026c6e5709ee99bdf9e198df4f0555449a
```

The mongodbMigrate image will be bumped to digest:
```
sha256:09737b304e52cdd0c8d9df1c37fb3a7c7d1d0814e13592fe7124cb028f9fa90c
```

The websocket image will be bumped to digest:
```
sha256:03adc92801da265635e762786c495b2740967e4a4f67a62c8ff916df47127e6e
```

Code diff contained in this image:

https://github.com/lnflash/flash/compare/1c6aecc...f44647c
