### PR TITLE
chore(deps): bump-flash-image-

### DIFF
--- a/charts/flash/Chart.yaml
+++ b/charts/flash/Chart.yaml
@@ -3,7 +3,7 @@ name: flash
 description: A Helm chart for the Flash application backend
 type: application
 version: 0.0.52
-appVersion: 0.6.21
+appVersion: 0.6.25
 dependencies:
   - name: redis
     repository: https://charts.bitnami.com/bitnami

--- a/charts/flash/values.yaml
+++ b/charts/flash/values.yaml
@@ -21,16 +21,16 @@ galoy:
       repository: lnflash/flash-app:edge
       imagePullPolicy: Always
       # digests managed by flash-app pipeline in concourse
-      digest: sha256:33c01d629b5046c9c2e488f7d4998e6c8d519038e776c159e4cf08e4a6e4628d
-      git_ref: "081bf79"
+      digest: sha256:6952603882ab987f2aca92e36bce65479609028da7dfe317e9dd7c6ebba07f5e
+      git_ref: "f3f9d46"
     websocket:
       repository: docker.io/lnflash/galoy-app-websocket
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:b53b9e592d2f965298e1b3fd6e4b2c64c07fd935e707d25ed630357f911cb628"
+      digest: "sha256:cc1e3804d427b53c94ccd2f96dee9dc5989bab53db692e36584a933da3f5452c"
     mongodbMigrate:
       repository: docker.io/lnflash/galoy-app-migrate
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:c7735236861f17c89f83e0cad079b9368d8f684de1272c38486edd92610f39c0"
+      digest: "sha256:385d922fcf0639cb046ee34cd49e7e7003ecce21530f5c99ec4816b92b739c2b"
     mongoBackup:
       repository: us.gcr.io/galoy-org/mongo-backup
       # Currently using Galoy's images. To make changes, see /images & /ci in this repo


### PR DESCRIPTION
# Bump flash image

The flash image will be bumped to digest:
```
sha256:165a16eebd426c0729a9d6e3589e2e3280fe7f8448d181e870ddb5b4fb452e95
```

The mongodbMigrate image will be bumped to digest:
```
sha256:e39f9d8ea2d996216fdf570cce311e8d594cc33be60575a795ad5c84f0a071a7
```

The websocket image will be bumped to digest:
```
sha256:4f1f4278370dbb4903eefee92873cf7eff1aee176b2de85d00df13fffeb0a797
```

Code diff contained in this image:

https://github.com/lnflash/flash/compare/081bf79...e95807a
