### PR TITLE
chore(deps): bump-flash-image-

### DIFF
--- a/charts/flash/Chart.yaml
+++ b/charts/flash/Chart.yaml
@@ -3,7 +3,7 @@ name: flash
 description: A Helm chart for the Flash application backend
 type: application
 version: 0.0.54
-appVersion: 0.6.26
+appVersion: 0.6.27
 dependencies:
   - name: redis
     repository: https://charts.bitnami.com/bitnami

--- a/charts/flash/apollo-router/supergraph.graphql
+++ b/charts/flash/apollo-router/supergraph.graphql
@@ -540,7 +540,7 @@ input IntraLedgerUsdPaymentSendInput
   @join__type(graph: PUBLIC)
 {
   """Amount in cents."""
-  amount: CentAmount!
+  amount: FractionalCentAmount!
 
   """Optional memo to be attached to the payment."""
   memo: Memo
@@ -761,7 +761,7 @@ input LnNoAmountUsdInvoicePaymentInput
   @join__type(graph: PUBLIC)
 {
   """Amount to pay in USD cents."""
-  amount: CentAmount!
+  amount: FractionalCentAmount!
 
   """Optional memo to associate with the lightning invoice."""
   memo: Memo
@@ -819,7 +819,7 @@ input LnUsdInvoiceCreateOnBehalfOfRecipientInput
   @join__type(graph: PUBLIC)
 {
   """Amount in USD cents."""
-  amount: CentAmount!
+  amount: FractionalCentAmount!
   descriptionHash: Hex32Bytes
 
   """Optional invoice expiration time in minutes."""
@@ -1005,7 +1005,7 @@ type Mutation
     associated with the amount).
   """
   lnUsdInvoiceCreateOnBehalfOfRecipient(input: LnUsdInvoiceCreateOnBehalfOfRecipientInput!): LnInvoicePayload!
-  lnUsdInvoiceFeeProbe(input: LnUsdInvoiceFeeProbeInput!): SatAmountPayload!
+  lnUsdInvoiceFeeProbe(input: LnUsdInvoiceFeeProbeInput!): CentAmountPayload!
   merchantMapSuggest(input: MerchantMapSuggestInput!): MerchantPayload!
   onChainAddressCreate(input: OnChainAddressCreateInput!): OnChainAddressPayload!
   onChainAddressCurrent(input: OnChainAddressCurrentInput!): OnChainAddressPayload!
@@ -1162,7 +1162,7 @@ input OnChainUsdPaymentSendInput
   @join__type(graph: PUBLIC)
 {
   address: OnChainAddress!
-  amount: CentAmount!
+  amount: FractionalCentAmount!
   memo: Memo
   speed: PayoutSpeed = FAST
   walletId: WalletId!

--- a/charts/flash/values.yaml
+++ b/charts/flash/values.yaml
@@ -21,16 +21,16 @@ galoy:
       repository: lnflash/flash-app:edge
       imagePullPolicy: Always
       # digests managed by flash-app pipeline in concourse
-      digest: sha256:0b85a7447a32a7a22497c28529cf7a89faa3053d11064d595c782b4633569312
-      git_ref: "be7b74e"
+      digest: sha256:9dfbd31c54cffa96708c8c3a999437adb158c7e9ec4b4f74510a03a72acaadfe
+      git_ref: "003c1c8"
     websocket:
       repository: docker.io/lnflash/galoy-app-websocket
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:cc3600bb32d6c2b7ae9b599c1c74c14ddd3abfe665293768eee6302b3e76f8f6"
+      digest: "sha256:5944d2a4f9fedb437644855c0dfea7e4661b0898a14256a047be5e447720a32e"
     mongodbMigrate:
       repository: docker.io/lnflash/galoy-app-migrate
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:4ce4f0915b85bc341e86cbe1a9ad68cf814bedf57451721e9c3d43eabd9d6f17"
+      digest: "sha256:2f7acdf432744c1655998473d8ac4d161cfd7a1df549c427656bbfa327f63d95"
     mongoBackup:
       repository: us.gcr.io/galoy-org/mongo-backup
       # Currently using Galoy's images. To make changes, see /images & /ci in this repo


### PR DESCRIPTION
# Bump flash image

The flash image will be bumped to digest:
```
sha256:9dfbd31c54cffa96708c8c3a999437adb158c7e9ec4b4f74510a03a72acaadfe
```

The mongodbMigrate image will be bumped to digest:
```
sha256:2f7acdf432744c1655998473d8ac4d161cfd7a1df549c427656bbfa327f63d95
```

The websocket image will be bumped to digest:
```
sha256:5944d2a4f9fedb437644855c0dfea7e4661b0898a14256a047be5e447720a32e
```

Code diff contained in this image:

https://github.com/lnflash/flash/compare/be7b74e...003c1c8
