### PR TITLE
chore(deps): bump-flash-image-

### DIFF
--- a/charts/flash/Chart.yaml
+++ b/charts/flash/Chart.yaml
@@ -3,7 +3,7 @@ name: flash
 description: A Helm chart for the Flash application backend
 type: application
 version: 0.0.55
-appVersion: 0.6.27
+appVersion: 0.6.29
 dependencies:
   - name: redis
     repository: https://charts.bitnami.com/bitnami

--- a/charts/flash/apollo-router/supergraph.graphql
+++ b/charts/flash/apollo-router/supergraph.graphql
@@ -752,7 +752,7 @@ input LnNoAmountInvoicePaymentInput
 input LnNoAmountUsdInvoiceFeeProbeInput
   @join__type(graph: PUBLIC)
 {
-  amount: CentAmount!
+  amount: FractionalCentAmount!
   paymentRequest: LnPaymentRequest!
   walletId: WalletId!
 }

--- a/charts/flash/values.yaml
+++ b/charts/flash/values.yaml
@@ -21,16 +21,16 @@ galoy:
       repository: lnflash/flash-app:edge
       imagePullPolicy: Always
       # digests managed by flash-app pipeline in concourse
-      digest: sha256:9dfbd31c54cffa96708c8c3a999437adb158c7e9ec4b4f74510a03a72acaadfe
-      git_ref: "003c1c8"
+      digest: sha256:0fa4e1926875819f831c0cd8f7ad8faa5c91e5be563285752cc3cd5f66f2512b
+      git_ref: "6cd3120"
     websocket:
       repository: docker.io/lnflash/galoy-app-websocket
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:5944d2a4f9fedb437644855c0dfea7e4661b0898a14256a047be5e447720a32e"
+      digest: "sha256:b2d16988055abc2877c1bbc070c90e0a7d656884c6e8ff1bd680f279418d1595"
     mongodbMigrate:
       repository: docker.io/lnflash/galoy-app-migrate
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:2f7acdf432744c1655998473d8ac4d161cfd7a1df549c427656bbfa327f63d95"
+      digest: "sha256:f94dd9d4bae90c59ed324271dff8553a731509990afdc1d66e04bb3d003aad7f"
     mongoBackup:
       repository: us.gcr.io/galoy-org/mongo-backup
       # Currently using Galoy's images. To make changes, see /images & /ci in this repo


### PR DESCRIPTION
# Bump flash image

The flash image will be bumped to digest:
```
sha256:1330f2d215038dbcacb84d3aadd9c53a11a8dc2c857520230331b793389fe75c
```

The mongodbMigrate image will be bumped to digest:
```
sha256:39bc988b56f0783c7caabe74ea022c623ce78476cbd830f41b651226904ad8d6
```

The websocket image will be bumped to digest:
```
sha256:e62e3a1a74f1e318c186e847af4b8c05f3c884785cd59e3930e434500f1849cd
```

Code diff contained in this image:

https://github.com/lnflash/flash/compare/003c1c8...3d88871
