### PR TITLE
chore(deps): bump-flash-image-

### DIFF
--- a/charts/flash/Chart.yaml
+++ b/charts/flash/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2 # https://helm.sh/docs/topics/charts/#the-apiversion-field
 name: flash
 description: A Helm chart for the Flash application backend
 type: application
-version: 0.0.67
-appVersion: 0.6.37
+version: 0.0.68
+appVersion: 0.6.38
 dependencies:
   - name: redis
     repository: https://charts.bitnami.com/bitnami

--- a/charts/flash/apollo-router/supergraph.graphql
+++ b/charts/flash/apollo-router/supergraph.graphql
@@ -277,6 +277,31 @@ input CaptchaRequestAuthCodeInput
   validationCode: String!
 }
 
+type CashoutOffer
+  @join__type(graph: PUBLIC)
+{
+  """The time at which this offer is no longer accepted by Flash"""
+  expiresAt: Timestamp!
+
+  """The amount that Flash is charging for it's services"""
+  flashFee: USDCents!
+
+  """ID of the offer"""
+  offerId: ID!
+
+  """The amount Flash owes to the user denominated in JMD as cents"""
+  receiveJmd: JMDCents!
+
+  """The amount Flash owes to the user denominated in USD as cents"""
+  receiveUsd: USDCents!
+
+  """The amount the user is sending to flash"""
+  send: USDCents!
+
+  """ID for the users USD wallet to send from"""
+  walletId: WalletId!
+}
+
 """(Positive) Cent amount (1/100 of a dollar)"""
 scalar CentAmount
   @join__type(graph: PUBLIC)
@@ -487,6 +512,14 @@ type GraphQLApplicationError implements Error
 scalar Hex32Bytes
   @join__type(graph: PUBLIC)
 
+input InitiateCashoutInput
+  @join__type(graph: PUBLIC)
+{
+  """The id of the offer being executed."""
+  offerId: ID!
+  walletId: WalletId!
+}
+
 union InitiationVia
   @join__type(graph: PUBLIC)
   @join__unionMember(graph: PUBLIC, member: "InitiationViaIntraLedger")
@@ -571,6 +604,10 @@ type IsFlashNpubPayload
   errors: [Error!]!
   isFlashNpub: Boolean
 }
+
+"""Amount in Jamaican cents"""
+scalar JMDCents
+  @join__type(graph: PUBLIC)
 
 scalar join__FieldSet
 
@@ -924,6 +961,12 @@ type Mutation
   feedbackSubmit(input: FeedbackSubmitInput!): SuccessPayload!
 
   """
+  Start the Cashout process; 
+  User sends USD to Flash via Ibex and receives USD or JMD to bank account.
+  """
+  initiateCashout(input: InitiateCashoutInput!): SuccessPayload!
+
+  """
   Actions a payment which is internal to the ledger e.g. it does
   not use onchain/lightning. Returns payment status (success,
   failed, pending, already_paid).
@@ -1015,6 +1058,12 @@ type Mutation
   onChainUsdPaymentSend(input: OnChainUsdPaymentSendInput!): PaymentSendPayload!
   onChainUsdPaymentSendAsBtcDenominated(input: OnChainUsdPaymentSendAsBtcDenominatedInput!): PaymentSendPayload!
   quizCompleted(input: QuizCompletedInput!): QuizCompletedPayload!
+
+  """
+  Returns an offer from Flash for a user to withdraw from their USD wallet (denominated in cents).
+  The user can review this offer and then execute the withdrawal by calling the initiateCashout mutation.
+  """
+  requestCashout(input: RequestCashoutInput!): RequestCashoutResponse!
   userContactUpdateAlias(input: UserContactUpdateAliasInput!): UserContactUpdateAliasPayload! @deprecated(reason: "will be moved to AccountContact")
   userEmailDelete: UserEmailDeletePayload!
   userEmailRegistrationInitiate(input: UserEmailRegistrationInitiateInput!): UserEmailRegistrationInitiatePayload!
@@ -1435,6 +1484,23 @@ type RealtimePricePayload
   realtimePrice: RealtimePrice
 }
 
+input RequestCashoutInput
+  @join__type(graph: PUBLIC)
+{
+  """Amount in USD cents."""
+  amount: USDCents!
+
+  """ID for a USD wallet belonging to the current user."""
+  walletId: WalletId!
+}
+
+type RequestCashoutResponse
+  @join__type(graph: PUBLIC)
+{
+  errors: [Error!]!
+  offer: CashoutOffer
+}
+
 """
 Non-fractional signed whole numeric value between -(2^53) + 1 and 2^53 - 1
 """
@@ -1624,6 +1690,10 @@ type UpgradePayload
   errors: [Error!]!
   success: Boolean!
 }
+
+"""Amount in USD cents"""
+scalar USDCents
+  @join__type(graph: PUBLIC)
 
 """
 A wallet belonging to an account which contains a USD balance and a list of transactions.

--- a/charts/flash/values.yaml
+++ b/charts/flash/values.yaml
@@ -21,16 +21,16 @@ galoy:
       repository: lnflash/flash-app:edge
       imagePullPolicy: Always
       # digests managed by flash-app pipeline in concourse
-      digest: sha256:01761b0e2cfde54405be8da3738beee2262bae879c5a4943f389f0ea55b03127
-      git_ref: "8b4fb94"
+      digest: sha256:bd9004fa0042c15770f38958cb342fd91c0859473b9da5fc89f35b5f60841cdd
+      git_ref: "fb62d8b"
     websocket:
       repository: docker.io/lnflash/galoy-app-websocket
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:f304b1823f9feacafa3ad714e59193322c712f6b210bc97e626ea97a7115ed50"
+      digest: "sha256:4391a3ebb684816e2835b2f829a7cae33deeb567308da093b8d8b05e0bc9e50f"
     mongodbMigrate:
       repository: docker.io/lnflash/galoy-app-migrate
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:53ab4bea715779a7561e6a37b290ac6528e5781d1d619b617e764bd22f77c17f"
+      digest: "sha256:25962ba062de501a447e7dc4ce044734f7ebb56bac7e2e7b747e37a3242decc8"
     mongoBackup:
       repository: us.gcr.io/galoy-org/mongo-backup
       # Currently using Galoy's images. To make changes, see /images & /ci in this repo


### PR DESCRIPTION
# Bump flash image

The flash image will be bumped to digest:
```
sha256:bd9004fa0042c15770f38958cb342fd91c0859473b9da5fc89f35b5f60841cdd
```

The mongodbMigrate image will be bumped to digest:
```
sha256:25962ba062de501a447e7dc4ce044734f7ebb56bac7e2e7b747e37a3242decc8
```

The websocket image will be bumped to digest:
```
sha256:4391a3ebb684816e2835b2f829a7cae33deeb567308da093b8d8b05e0bc9e50f
```

Code diff contained in this image:

https://github.com/lnflash/flash/compare/8b4fb94...fb62d8b
