### PR TITLE
chore(deps): bump-flash-image-

### DIFF
--- a/charts/flash/Chart.yaml
+++ b/charts/flash/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2 # https://helm.sh/docs/topics/charts/#the-apiversion-field
 name: flash
 description: A Helm chart for the Flash application backend
 type: application
-version: 0.0.71
+version: 0.0.72
 appVersion: 0.7.0
 dependencies:
   - name: redis

--- a/charts/flash/Chart.yaml
+++ b/charts/flash/Chart.yaml
@@ -3,7 +3,7 @@ name: flash
 description: A Helm chart for the Flash application backend
 type: application
 version: 0.0.71
-appVersion: 0.6.38
+appVersion: 0.7.0
 dependencies:
   - name: redis
     repository: https://charts.bitnami.com/bitnami

--- a/charts/flash/apollo-router/supergraph.graphql
+++ b/charts/flash/apollo-router/supergraph.graphql
@@ -280,6 +280,9 @@ input CaptchaRequestAuthCodeInput
 type CashoutOffer
   @join__type(graph: PUBLIC)
 {
+  """The rate used when withdrawing to a JMD bank account"""
+  exchangeRate: JMDCents!
+
   """The time at which this offer is no longer accepted by Flash"""
   expiresAt: Timestamp!
 
@@ -1049,7 +1052,7 @@ type Mutation
     associated with the amount).
   """
   lnUsdInvoiceCreateOnBehalfOfRecipient(input: LnUsdInvoiceCreateOnBehalfOfRecipientInput!): LnInvoicePayload!
-  lnUsdInvoiceFeeProbe(input: LnUsdInvoiceFeeProbeInput!): CentAmountPayload!
+  lnUsdInvoiceFeeProbe(input: LnUsdInvoiceFeeProbeInput!): UsdInvoiceEstimate!
   merchantMapSuggest(input: MerchantMapSuggestInput!): MerchantPayload!
   onChainAddressCreate(input: OnChainAddressCreateInput!): OnChainAddressPayload!
   onChainAddressCurrent(input: OnChainAddressCurrentInput!): OnChainAddressPayload!
@@ -1694,6 +1697,14 @@ type UpgradePayload
 """Amount in USD cents"""
 scalar USDCents
   @join__type(graph: PUBLIC)
+
+type UsdInvoiceEstimate
+  @join__type(graph: PUBLIC)
+{
+  errors: [Error!]!
+  fee: USDCents
+  invoiceAmount: USDCents
+}
 
 """
 A wallet belonging to an account which contains a USD balance and a list of transactions.

--- a/charts/flash/templates/websocket-ingress.yaml
+++ b/charts/flash/templates/websocket-ingress.yaml
@@ -18,6 +18,10 @@ metadata:
     nginx.ingress.kubernetes.io/limit-rpm: "10"
     nginx.ingress.kubernetes.io/limit-burst-multiplier: "2"
     nginx.ingress.kubernetes.io/limit-connections: "10"
+    nginx.ingress.kubernetes.io/server-snippet: |
+      real_ip_header X-Forwarded-For;
+      set_real_ip_from 10.0.0.0/8;
+      real_ip_recursive on;
     {{- with .Values.galoy.websocket.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/flash/values.yaml
+++ b/charts/flash/values.yaml
@@ -16,27 +16,25 @@ galoy:
       coldStorage:
         walletName: cold
         hotToColdRebalanceQueueName: dev
-
     exchangeRates:
       USD:
         JMD:
-          bid: 
-          ask: 
+          bid:
+          ask:
     cashout:
-      minimum: 
-        amount: 
+      minimum:
+        amount:
         currency: USD
-      maximum: 
-        amount: 
+      maximum:
+        amount:
         currency: USD
       accountLevel: 2
       fee: 200 # basis points
       duration: 600 # seconds
       email:
-        to: 
-        from: 
+        to:
+        from:
         subject: "New Cashout"
-
     ibex:
       url:
       email:
@@ -45,23 +43,22 @@ galoy:
         uri:
         port: 4008
         secret: "not-so-secret"
-
   images:
     app:
       repository: lnflash/flash-app
       tag: 0.7.0
       imagePullPolicy: Always
       # digests managed by flash-app pipeline in concourse
-      digest: sha256:bd9004fa0042c15770f38958cb342fd91c0859473b9da5fc89f35b5f60841cdd
-      git_ref: "fb62d8b"
+      digest: sha256:2f303255b20e4264e5ae73ed1484e2ee196fa7f8474eef3b6b963536a424eb0e
+      git_ref: "ce0b2e1"
     websocket:
       repository: docker.io/lnflash/galoy-app-websocket
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:4391a3ebb684816e2835b2f829a7cae33deeb567308da093b8d8b05e0bc9e50f"
+      digest: "sha256:3f483434f37755c7b0ab691f47837a5f6591fad0c54172c5a7072edfe4e3719a"
     mongodbMigrate:
       repository: docker.io/lnflash/galoy-app-migrate
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:25962ba062de501a447e7dc4ce044734f7ebb56bac7e2e7b747e37a3242decc8"
+      digest: "sha256:623202620c6c5dcc10c06a6033c00dab5b2b4b812ebb701376b892a15fc990ce"
     mongoBackup:
       repository: us.gcr.io/galoy-org/mongo-backup
       # Currently using Galoy's images. To make changes, see /images & /ci in this repo


### PR DESCRIPTION
# Bump flash image

The flash image will be bumped to digest:
```
sha256:2f303255b20e4264e5ae73ed1484e2ee196fa7f8474eef3b6b963536a424eb0e
```

The mongodbMigrate image will be bumped to digest:
```
sha256:623202620c6c5dcc10c06a6033c00dab5b2b4b812ebb701376b892a15fc990ce
```

The websocket image will be bumped to digest:
```
sha256:3f483434f37755c7b0ab691f47837a5f6591fad0c54172c5a7072edfe4e3719a
```

Code diff contained in this image:

https://github.com/lnflash/flash/compare/fb62d8b...ce0b2e1
