### PR TITLE
chore(deps): bump-flash-image-

### DIFF
--- a/charts/flash/Chart.yaml
+++ b/charts/flash/Chart.yaml
@@ -3,7 +3,7 @@ name: flash
 description: A Helm chart for the Flash application backend
 type: application
 version: 0.0.72
-appVersion: 0.7.0
+appVersion: 0.7.1
 dependencies:
   - name: redis
     repository: https://charts.bitnami.com/bitnami

--- a/charts/flash/Chart.yaml
+++ b/charts/flash/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2 # https://helm.sh/docs/topics/charts/#the-apiversion-field
 name: flash
 description: A Helm chart for the Flash application backend
 type: application
-version: 0.0.72
+version: 0.0.73
 appVersion: 0.7.1
 dependencies:
   - name: redis

--- a/charts/flash/apollo-router/supergraph.graphql
+++ b/charts/flash/apollo-router/supergraph.graphql
@@ -312,8 +312,9 @@ scalar CentAmount
 type CentAmountPayload
   @join__type(graph: PUBLIC)
 {
-  amount: CentAmount
+  amount: USDCents
   errors: [Error!]!
+  invoiceAmount: USDCents
 }
 
 type ConsumerAccount implements Account
@@ -1052,7 +1053,7 @@ type Mutation
     associated with the amount).
   """
   lnUsdInvoiceCreateOnBehalfOfRecipient(input: LnUsdInvoiceCreateOnBehalfOfRecipientInput!): LnInvoicePayload!
-  lnUsdInvoiceFeeProbe(input: LnUsdInvoiceFeeProbeInput!): UsdInvoiceEstimate!
+  lnUsdInvoiceFeeProbe(input: LnUsdInvoiceFeeProbeInput!): CentAmountPayload!
   merchantMapSuggest(input: MerchantMapSuggestInput!): MerchantPayload!
   onChainAddressCreate(input: OnChainAddressCreateInput!): OnChainAddressPayload!
   onChainAddressCurrent(input: OnChainAddressCurrentInput!): OnChainAddressPayload!
@@ -1697,14 +1698,6 @@ type UpgradePayload
 """Amount in USD cents"""
 scalar USDCents
   @join__type(graph: PUBLIC)
-
-type UsdInvoiceEstimate
-  @join__type(graph: PUBLIC)
-{
-  errors: [Error!]!
-  fee: USDCents
-  invoiceAmount: USDCents
-}
 
 """
 A wallet belonging to an account which contains a USD balance and a list of transactions.

--- a/charts/flash/values.yaml
+++ b/charts/flash/values.yaml
@@ -49,16 +49,16 @@ galoy:
       tag: 0.7.0
       imagePullPolicy: Always
       # digests managed by flash-app pipeline in concourse
-      digest: sha256:2f303255b20e4264e5ae73ed1484e2ee196fa7f8474eef3b6b963536a424eb0e
-      git_ref: "ce0b2e1"
+      digest: sha256:bcc73218d4f8357ec4ac95c01faec77885d6789c222cb50de98d1cac73d5be0f
+      git_ref: "f548b99"
     websocket:
       repository: docker.io/lnflash/galoy-app-websocket
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:3f483434f37755c7b0ab691f47837a5f6591fad0c54172c5a7072edfe4e3719a"
+      digest: "sha256:b632fc1f8de44f745dc40b0057de547eb7686d026657c5b9949e289c72f6d266"
     mongodbMigrate:
       repository: docker.io/lnflash/galoy-app-migrate
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:623202620c6c5dcc10c06a6033c00dab5b2b4b812ebb701376b892a15fc990ce"
+      digest: "sha256:c01dd0d29cf3b8ff413bb3d8b21e32fd7c24ae56d19967db0e829c5f2288745a"
     mongoBackup:
       repository: us.gcr.io/galoy-org/mongo-backup
       # Currently using Galoy's images. To make changes, see /images & /ci in this repo


### PR DESCRIPTION
# Bump flash image

The flash image will be bumped to digest:
```
sha256:bcc73218d4f8357ec4ac95c01faec77885d6789c222cb50de98d1cac73d5be0f
```

The mongodbMigrate image will be bumped to digest:
```
sha256:c01dd0d29cf3b8ff413bb3d8b21e32fd7c24ae56d19967db0e829c5f2288745a
```

The websocket image will be bumped to digest:
```
sha256:b632fc1f8de44f745dc40b0057de547eb7686d026657c5b9949e289c72f6d266
```

Code diff contained in this image:

https://github.com/lnflash/flash/compare/ce0b2e1...f548b99
