### PR TITLE
Release strfry PVC on rollout

### DIFF
--- a/charts/nostr/strfry/Chart.yaml
+++ b/charts/nostr/strfry/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/nostr/strfry/templates/deployment.yaml
+++ b/charts/nostr/strfry/templates/deployment.yaml
@@ -4,6 +4,8 @@ metadata:
   name: {{ include "strfry.name" . }}
 spec:
   replicas: 1
+  strategy:
+    type: Recreate # Deletes existing pods (& their PVCs) before creating new ones
   selector:
     matchLabels:
       app: strfry


### PR DESCRIPTION
Currently, the PersistentVolumeClaim (PVC) is preventing a new pod from being created when rolling out a new deployment. Changing the rollout strategy to `recreate` deletes the existing pod before creating a new one, which releases the PVC so the new pod can claim it. 
