### PR TITLE
Reference proxy_protocol for websocket client IP

### DIFF
--- a/charts/flash/templates/websocket-ingress.yaml
+++ b/charts/flash/templates/websocket-ingress.yaml
@@ -18,8 +18,9 @@ metadata:
     nginx.ingress.kubernetes.io/limit-rpm: "10"
     nginx.ingress.kubernetes.io/limit-burst-multiplier: "2"
     nginx.ingress.kubernetes.io/limit-connections: "10"
+    nginx.ingress.kubernetes.io/limit-whitelist: ""
     nginx.ingress.kubernetes.io/server-snippet: |
-      real_ip_header X-Forwarded-For;
+      real_ip_header proxy_protocol;
       set_real_ip_from 10.0.0.0/8;
       real_ip_recursive on;
     {{- with .Values.galoy.websocket.ingress.annotations }}


### PR DESCRIPTION
We're using the PROXY protocol to forward client IP. Websocket ingress should use this field when enforcing connection limits