### PR TITLE
Use oathkeeper proxy for internal api calls

### DIFF
--- a/charts/flash-pay/Chart.yaml
+++ b/charts/flash-pay/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.6
+version: 0.0.7
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/flash-pay/templates/deployment.yaml
+++ b/charts/flash-pay/templates/deployment.yaml
@@ -32,7 +32,7 @@ spec:
         - name: NEXT_PUBLIC_GRAPHQL_WEBSOCKET_URL
           value: "{{ .Values.graphqlWebsocketUrl }}"
         - name: GRAPHQL_HOSTNAME_INTERNAL
-          value: "{{ .Values.graphqlHost }}"
+          value: "{{ .Values.oathkeeper.service.host }}:{{ .Values.oathkeeper.service.port }}"
         - name: NOSTR_PUBKEY
           value: "{{ .Values.nostrPubkey }}"
         - name: REDIS_MASTER_NAME

--- a/charts/flash-pay/values.yaml
+++ b/charts/flash-pay/values.yaml
@@ -8,7 +8,10 @@ service:
   port: 80
   type: ClusterIP
 graphqlUrl: 
-graphqlHost: 
+oathkeeper:
+  service:
+    host: flash-oathkeeper-proxy.flash.svc.cluster.local
+    port: 4455
 graphqlWebsocketUrl: 
 nostrPubkey: "npub1qqqqqqrm4aehwh4t0mknaxvaqvhxdrvrnquz7a7npdgll3lezkpqq3j5a5"
 galoy-nostr:


### PR DESCRIPTION
Calls to the GraphQL api are failing when using the external URL because the external URL is routed through `nginx` which is expecting headers as defined by the PROXY protocol. The changes here by-pass the call to nginx by calling oathkeeper directly