### PR TITLE
chore(deps): bump-flash-image-

### DIFF
--- a/charts/flash/Chart.yaml
+++ b/charts/flash/Chart.yaml
@@ -3,7 +3,7 @@ name: flash
 description: A Helm chart for the Flash application backend
 type: application
 version: 0.0.79
-appVersion: 0.7.6
+appVersion: 0.7.10
 dependencies:
   - name: redis
     repository: https://charts.bitnami.com/bitnami

--- a/charts/flash/apollo-router/supergraph.graphql
+++ b/charts/flash/apollo-router/supergraph.graphql
@@ -1436,6 +1436,7 @@ type Query
 
   """Returns 1 Sat and 1 Usd Cent price for the given currency"""
   realtimePrice(currency: DisplayCurrency = "USD"): RealtimePrice!
+  transactionDetails(input: TransactionDetailsInput!): TransactionDetailsPayload!
   userDefaultWalletId(username: Username!): WalletId! @deprecated(reason: "will be migrated to AccountDefaultWalletId")
   usernameAvailable(username: Username!): Boolean
 }
@@ -1657,6 +1658,81 @@ type TransactionConnection
 
   """Information to aid in pagination."""
   pageInfo: PageInfo!
+}
+
+type TransactionDetails
+  @join__type(graph: PUBLIC)
+{
+  """Account ID associated with the transaction"""
+  accountId: String
+
+  """Bitcoin address for onchain transactions"""
+  address: String
+
+  """Transaction amount"""
+  amount: Float
+
+  """Number of confirmations for onchain transactions"""
+  confirmations: Int
+
+  """Transaction creation timestamp"""
+  createdAt: String
+
+  """Transaction currency"""
+  currency: String
+
+  """Transaction fee"""
+  fee: Float
+
+  """Transaction ID"""
+  id: String!
+
+  """Lightning invoice (bolt11)"""
+  invoice: String
+
+  """Transaction memo/description"""
+  memo: String
+
+  """Lightning payment hash"""
+  paymentHash: String
+
+  """Lightning payment preimage"""
+  paymentPreimage: String
+
+  """Transaction status"""
+  status: String
+
+  """Bitcoin transaction ID for onchain transactions"""
+  txid: String
+
+  """Transaction type (lightning/onchain)"""
+  type: String
+
+  """Transaction last update timestamp"""
+  updatedAt: String
+
+  """Output index for onchain transactions"""
+  vout: Int
+}
+
+type TransactionDetailsError
+  @join__type(graph: PUBLIC)
+{
+  message: String!
+}
+
+input TransactionDetailsInput
+  @join__type(graph: PUBLIC)
+{
+  """Transaction ID to fetch details for"""
+  transactionId: String!
+}
+
+type TransactionDetailsPayload
+  @join__type(graph: PUBLIC)
+{
+  errors: [TransactionDetailsError!]!
+  transactionDetails: TransactionDetails
 }
 
 """An edge in a connection."""

--- a/charts/flash/values.yaml
+++ b/charts/flash/values.yaml
@@ -48,16 +48,16 @@ galoy:
       repository: lnflash/flash-app
       imagePullPolicy: Always
       # digests managed by flash-app pipeline in concourse
-      digest: sha256:faa57cd6b1d150e8b5d5ac0d192bdad7b3073c39d3652638705437d19b7e1100
-      git_ref: "59946dc"
+      digest: sha256:1ae671a19b1a98ee291931c5aca9f4432000d2746e028f88dde8c20f861d55d8
+      git_ref: "f4abdf7"
     websocket:
       repository: docker.io/lnflash/galoy-app-websocket
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:93bb3df441b259efc2fc83e5ef56c0fdbdd5b0447f7aef6f407bff3c19382576"
+      digest: "sha256:db9b22503191aae1fc18ebf36659d797840fae86b6c56616346ae06c8d2daeaf"
     mongodbMigrate:
       repository: docker.io/lnflash/galoy-app-migrate
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:97d814ff053c3fb255b00148c0473738649e1e9de56cd5e6dc4e5fc761fc5466"
+      digest: "sha256:1d68b74b382842ed9cbced1f7d72bdcb8d28836ee7b2a4208ad09b625b21e1ff"
     mongoBackup:
       repository: us.gcr.io/galoy-org/mongo-backup
       # Currently using Galoy's images. To make changes, see /images & /ci in this repo


### PR DESCRIPTION
# Bump flash image

The flash image will be bumped to digest:
```
sha256:45e61e56b4d937386d0674d8d59c14a97e14d9414ffe6c148db5c32ebc2ad73b
```

The mongodbMigrate image will be bumped to digest:
```
sha256:5f882933e6f1868a7116ad4ae08012cdf0d3d33c72a97509d65c43675acb4320
```

The websocket image will be bumped to digest:
```
sha256:db6ee6f6a68938de10960b7b77fa9e3d3cab5ad06274731e6dfb8c425d86a463
```

Code diff contained in this image:

https://github.com/lnflash/flash/compare/59946dc...7859aa4
