### PR TITLE
Add nsec as env variable

### DIFF
--- a/charts/flash/Chart.yaml
+++ b/charts/flash/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2 # https://helm.sh/docs/topics/charts/#the-apiversion-field
 name: flash
 description: A Helm chart for the Flash application backend
 type: application
-version: 0.0.81
+version: 0.0.82
 appVersion: 0.7.12
 dependencies:
   - name: redis

--- a/charts/flash/templates/ibex-webhook-deployment.yaml
+++ b/charts/flash/templates/ibex-webhook-deployment.yaml
@@ -67,6 +67,12 @@ spec:
           value: {{ .Values.tracing.otelExporterOtlpEndpoint | quote }}
         - name: TRACING_SERVICE_NAME
           value: "{{ .Values.tracing.prefix }}-{{ template "galoy.ibex.webhook.fullname" . }}"
+        - name: NOSTR_PRIVATE_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.galoy.nostr.zapReceiptsExistingSecret.name }}
+              key: {{ .Values.galoy.nostr.zapReceiptsExistingSecret.key }}
+
 {{/* Databases */}}
 {{ include "galoy.mongodb.env" . | indent 8 }}
 {{ include "galoy.redis.env" . | indent 8 }}

--- a/charts/flash/values.yaml
+++ b/charts/flash/values.yaml
@@ -342,6 +342,11 @@ galoy:
     name: proxy-check-api-key
     key: api-key
   mattermostWebhookUrl: "mattermostwebhookurl"
+  nostr:
+    zapReceiptsExistingSecret:
+      name: "flash-nostr-keys"
+      key: "zapReceipts"
+
 # Ref: https://artifacthub.io/packages/helm/bitnami/mongodb/
 mongodb:
   image:


### PR DESCRIPTION
Zap receipts feature requires signing with an nsec. This allows an nsec to be read as an environment variable from an externally defined kubernetes secret.