### PR TITLE
chore(deps): bump-flash-image-

### DIFF
--- a/charts/flash/Chart.yaml
+++ b/charts/flash/Chart.yaml
@@ -3,7 +3,7 @@ name: flash
 description: A Helm chart for the Flash application backend
 type: application
 version: 0.0.86
-appVersion: 0.7.14
+appVersion: 0.7.16
 dependencies:
   - name: redis
     repository: https://charts.bitnami.com/bitnami

--- a/charts/flash/apollo-router/supergraph.graphql
+++ b/charts/flash/apollo-router/supergraph.graphql
@@ -155,6 +155,32 @@ type AccountUpdateNotificationSettingsPayload
   errors: [Error!]!
 }
 
+type AccountUpgradeRequest
+  @join__type(graph: PUBLIC)
+{
+  businessAddress: String
+  businessName: String
+  currentLevel: AccountLevel!
+  email: String
+  fullName: String!
+
+  """ERPNext document name"""
+  name: String!
+  phoneNumber: String
+  requestedLevel: AccountLevel!
+
+  """Workflow status of the upgrade request"""
+  status: String!
+  username: String!
+}
+
+type AccountUpgradeRequestPayload
+  @join__type(graph: PUBLIC)
+{
+  errors: [Error!]!
+  upgradeRequest: AccountUpgradeRequest
+}
+
 """An Opaque Bearer token"""
 scalar AuthToken
   @join__type(graph: PUBLIC)
@@ -222,6 +248,24 @@ type BuildInformation
 {
   commitHash: String
   helmRevision: Int
+}
+
+input BusinessAccountUpgradeRequestInput
+  @join__type(graph: PUBLIC)
+{
+  accountNumber: Int
+  accountType: String
+  bankBranch: String
+  bankName: String
+  businessAddress: String
+  businessName: String
+  currency: String
+  email: String
+  fullName: String!
+  idDocument: String
+  level: AccountLevel!
+  phoneNumber: String
+  terminalRequested: Boolean
 }
 
 type CallbackEndpoint
@@ -966,6 +1010,7 @@ type Mutation
   accountEnableNotificationChannel(input: AccountEnableNotificationChannelInput!): AccountUpdateNotificationSettingsPayload!
   accountUpdateDefaultWalletId(input: AccountUpdateDefaultWalletIdInput!): AccountUpdateDefaultWalletIdPayload!
   accountUpdateDisplayCurrency(input: AccountUpdateDisplayCurrencyInput!): AccountUpdateDisplayCurrencyPayload!
+  businessAccountUpgradeRequest(input: BusinessAccountUpgradeRequestInput!): SuccessPayload!
   callbackEndpointAdd(input: CallbackEndpointAddInput!): CallbackEndpointAddPayload!
   callbackEndpointDelete(input: CallbackEndpointDeleteInput!): SuccessPayload!
   captchaCreateChallenge: CaptchaCreateChallengePayload!
@@ -1419,6 +1464,7 @@ type Query
   @join__type(graph: PUBLIC)
 {
   accountDefaultWallet(username: Username!, walletCurrency: WalletCurrency): PublicWallet!
+  accountUpgradeRequest: AccountUpgradeRequestPayload!
   btcPrice(currency: DisplayCurrency! = "USD"): Price @deprecated(reason: "Deprecated in favor of realtimePrice")
   btcPriceList(range: PriceGraphRange!): [PricePoint]
   businessMapMarkers: [MapMarker!]!

--- a/charts/flash/values.yaml
+++ b/charts/flash/values.yaml
@@ -48,16 +48,16 @@ galoy:
       repository: lnflash/flash-app
       imagePullPolicy: Always
       # digests managed by flash-app pipeline in concourse
-      digest: sha256:79481ab16b38617664bade9c54c4f5c858fd469c4634f94e96e5c31bd2d1673c
-      git_ref: "37679e5"
+      digest: sha256:cc840b2f49b08d64369849b1971e4f08a3ecc0ec86c6a57254f11adf608addc9
+      git_ref: "4dfeed0"
     websocket:
       repository: docker.io/lnflash/galoy-app-websocket
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:dd07e0441fd732ac8aae5562950da4b54697238cd44ab7aae4b6c77e0defc60a"
+      digest: "sha256:e00b6d9c0266603a47e0c1d5ecd3a6e829922053f8a594e46d5ed7b0cb115e33"
     mongodbMigrate:
       repository: docker.io/lnflash/galoy-app-migrate
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:00522da73c991183ccd7026f6be99e4afb5c055596a4b3d6a775a0850d086c59"
+      digest: "sha256:2a93085b931cc9a6e6916126b905f1e74e62e36c9a4ed42b41e483baa06c81d9"
     mongoBackup:
       repository: us.gcr.io/galoy-org/mongo-backup
       # Currently using Galoy's images. To make changes, see /images & /ci in this repo


### PR DESCRIPTION
# Bump flash image

The flash image will be bumped to digest:
```
sha256:d0a8db3d5cbac3faa2e4bde21c96659864cf55c7cf32bd8b15babae010532110
```

The mongodbMigrate image will be bumped to digest:
```
sha256:360e62e8b6fa0d0a7024640e7857bd8387ced6912a55eaf8faf0bff15f032341
```

The websocket image will be bumped to digest:
```
sha256:ca076c74cf988b52cabbb472cb98010c65720b9af11568edac444c2ba00f0e29
```

Code diff contained in this image:

https://github.com/lnflash/flash/compare/37679e5...e702bef
