### PR TITLE
chore(deps): bump-flash-image-

### DIFF
--- a/charts/flash/Chart.yaml
+++ b/charts/flash/Chart.yaml
@@ -3,7 +3,7 @@ name: flash
 description: A Helm chart for the Flash application backend
 type: application
 version: 0.0.86
-appVersion: 0.7.14
+appVersion: 0.7.18
 dependencies:
   - name: redis
     repository: https://charts.bitnami.com/bitnami

--- a/charts/flash/apollo-router/supergraph.graphql
+++ b/charts/flash/apollo-router/supergraph.graphql
@@ -155,6 +155,32 @@ type AccountUpdateNotificationSettingsPayload
   errors: [Error!]!
 }
 
+type AccountUpgradeRequest
+  @join__type(graph: PUBLIC)
+{
+  businessAddress: String
+  businessName: String
+  currentLevel: AccountLevel!
+  email: String
+  fullName: String!
+
+  """ERPNext document name"""
+  name: String!
+  phoneNumber: String
+  requestedLevel: AccountLevel!
+
+  """Workflow status of the upgrade request"""
+  status: String!
+  username: String!
+}
+
+type AccountUpgradeRequestPayload
+  @join__type(graph: PUBLIC)
+{
+  errors: [Error!]!
+  upgradeRequest: AccountUpgradeRequest
+}
+
 """An Opaque Bearer token"""
 scalar AuthToken
   @join__type(graph: PUBLIC)
@@ -222,6 +248,24 @@ type BuildInformation
 {
   commitHash: String
   helmRevision: Int
+}
+
+input BusinessAccountUpgradeRequestInput
+  @join__type(graph: PUBLIC)
+{
+  accountNumber: Int
+  accountType: String
+  bankBranch: String
+  bankName: String
+  businessAddress: String
+  businessName: String
+  currency: String
+  email: String
+  fullName: String!
+  idDocument: String
+  level: AccountLevel!
+  phoneNumber: String
+  terminalRequested: Boolean
 }
 
 type CallbackEndpoint
@@ -517,6 +561,28 @@ type GraphQLApplicationError implements Error
 """Hex-encoded string of 32 bytes"""
 scalar Hex32Bytes
   @join__type(graph: PUBLIC)
+
+input IdDocumentUploadUrlGenerateInput
+  @join__type(graph: PUBLIC)
+{
+  """MIME type (image/jpeg, image/png, image/webp)"""
+  contentType: String!
+
+  """Original filename"""
+  filename: String!
+}
+
+type IdDocumentUploadUrlPayload
+  @join__type(graph: PUBLIC)
+{
+  errors: [Error!]!
+
+  """Storage key for the uploaded file (use to generate read URLs)"""
+  fileKey: String
+
+  """Pre-signed URL for uploading the ID document directly to storage"""
+  uploadUrl: String
+}
 
 input InitiateCashoutInput
   @join__type(graph: PUBLIC)
@@ -966,12 +1032,14 @@ type Mutation
   accountEnableNotificationChannel(input: AccountEnableNotificationChannelInput!): AccountUpdateNotificationSettingsPayload!
   accountUpdateDefaultWalletId(input: AccountUpdateDefaultWalletIdInput!): AccountUpdateDefaultWalletIdPayload!
   accountUpdateDisplayCurrency(input: AccountUpdateDisplayCurrencyInput!): AccountUpdateDisplayCurrencyPayload!
+  businessAccountUpgradeRequest(input: BusinessAccountUpgradeRequestInput!): SuccessPayload!
   callbackEndpointAdd(input: CallbackEndpointAddInput!): CallbackEndpointAddPayload!
   callbackEndpointDelete(input: CallbackEndpointDeleteInput!): SuccessPayload!
   captchaCreateChallenge: CaptchaCreateChallengePayload!
   captchaRequestAuthCode(input: CaptchaRequestAuthCodeInput!): SuccessPayload!
   deviceNotificationTokenCreate(input: DeviceNotificationTokenCreateInput!): SuccessPayload!
   feedbackSubmit(input: FeedbackSubmitInput!): SuccessPayload!
+  idDocumentUploadUrlGenerate(input: IdDocumentUploadUrlGenerateInput!): IdDocumentUploadUrlPayload!
 
   """
   Start the Cashout process; 
@@ -1419,6 +1487,7 @@ type Query
   @join__type(graph: PUBLIC)
 {
   accountDefaultWallet(username: Username!, walletCurrency: WalletCurrency): PublicWallet!
+  accountUpgradeRequest: AccountUpgradeRequestPayload!
   btcPrice(currency: DisplayCurrency! = "USD"): Price @deprecated(reason: "Deprecated in favor of realtimePrice")
   btcPriceList(range: PriceGraphRange!): [PricePoint]
   businessMapMarkers: [MapMarker!]!

--- a/charts/flash/values.yaml
+++ b/charts/flash/values.yaml
@@ -48,16 +48,16 @@ galoy:
       repository: lnflash/flash-app
       imagePullPolicy: Always
       # digests managed by flash-app pipeline in concourse
-      digest: sha256:79481ab16b38617664bade9c54c4f5c858fd469c4634f94e96e5c31bd2d1673c
-      git_ref: "37679e5"
+      digest: sha256:198004a480ee8ec931b213c7fd1a1b3abb1b5cdbf89a070f50bae6964110074b
+      git_ref: "87a97ac"
     websocket:
       repository: docker.io/lnflash/galoy-app-websocket
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:dd07e0441fd732ac8aae5562950da4b54697238cd44ab7aae4b6c77e0defc60a"
+      digest: "sha256:181be8d461953c9c3e9a1b8dc0d62238c56796514c8e6928330523189467f945"
     mongodbMigrate:
       repository: docker.io/lnflash/galoy-app-migrate
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:00522da73c991183ccd7026f6be99e4afb5c055596a4b3d6a775a0850d086c59"
+      digest: "sha256:57d269fbe72c8d158a358993313692e04c61fc7cefa9109ec21441116e104044"
     mongoBackup:
       repository: us.gcr.io/galoy-org/mongo-backup
       # Currently using Galoy's images. To make changes, see /images & /ci in this repo


### PR DESCRIPTION
# Bump flash image

The flash image will be bumped to digest:
```
sha256:478cf8e9ca4aa49f3be6068be54f8d2eef7255ce7a51dd3e755db75040f60d52
```

The mongodbMigrate image will be bumped to digest:
```
sha256:cd462325dda71ec4ee5492ae2df0b0ea4891c0b69ffa7aa637024fedd21a3c05
```

The websocket image will be bumped to digest:
```
sha256:1af29b5610486f614862611ae84517178ca6d5cf96d3095fc4331886dab320cd
```

Code diff contained in this image:

https://github.com/lnflash/flash/compare/37679e5...5d97e3e
