### PR TITLE
chore(deps): bump-flash-image-

### DIFF
--- a/charts/flash/Chart.yaml
+++ b/charts/flash/Chart.yaml
@@ -3,7 +3,7 @@ name: flash
 description: A Helm chart for the Flash application backend
 type: application
 version: 3.1.0
-appVersion: 0.7.37
+appVersion: 0.7.39
 dependencies:
   - name: redis
     repository: https://charts.bitnami.com/bitnami

--- a/charts/flash/values.yaml
+++ b/charts/flash/values.yaml
@@ -48,16 +48,16 @@ galoy:
       repository: lnflash/flash-app
       imagePullPolicy: Always
       # digests managed by flash-app pipeline in concourse
-      digest: sha256:c052c8568ff0e7e6fc766e5194c19d8b56b8c522d2be87d7a2619faa9e79628b
-      git_ref: "4f6e389"
+      digest: sha256:085b1cc610cb526a8fa3248bc5762ca25bc3877b6757107c5c176ccede2145a5
+      git_ref: "1ce14e5"
     websocket:
       repository: docker.io/lnflash/galoy-app-websocket
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:13360c2eb93878308d71faf74753a0260385d0985c28fbe038efbb5221543682"
+      digest: "sha256:ec936c819ad73377d8a79aa6c2b76cf7553871801eef7d7b1d736452400e8dcc"
     mongodbMigrate:
       repository: docker.io/lnflash/galoy-app-migrate
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:b6e1788965022d14585d39f336563102576b50ed815195c12aabc784a7fc8c4e"
+      digest: "sha256:75b3a0f4d9e8e2bd1c5ae324bdc8a2cab7a9fb4062ceb707bd076e869a8a8432"
     mongoBackup:
       repository: us.gcr.io/galoy-org/mongo-backup
       # Currently using Galoy's images. To make changes, see /images & /ci in this repo


### PR DESCRIPTION
# Bump flash image

The flash image will be bumped to digest:
```
sha256:ee2212caa55a9810766fb567dee226618605f73408cbbe3d4be2d898ef89a552
```

The mongodbMigrate image will be bumped to digest:
```
sha256:cb527ece0721605fff3810b0d67179474dbb67db2c120d512b697450926c224f
```

The websocket image will be bumped to digest:
```
sha256:9f051b83d38bb5c4dd055421b3d1213c364fa0be4686d7510abcbd35cb0a6e58
```

Code diff contained in this image:

https://github.com/lnflash/flash/compare/4f6e389...d8b7b35
