### PR TITLE
chore(deps): bump-flash-image-

### DIFF
--- a/charts/flash/Chart.yaml
+++ b/charts/flash/Chart.yaml
@@ -3,7 +3,7 @@ name: flash
 description: A Helm chart for the Flash application backend
 type: application
 version: 3.1.0
-appVersion: 0.7.37
+appVersion: 0.7.41
 dependencies:
   - name: redis
     repository: https://charts.bitnami.com/bitnami

--- a/charts/flash/apollo-router/supergraph.graphql
+++ b/charts/flash/apollo-router/supergraph.graphql
@@ -57,32 +57,6 @@ type AccountDeletePayload
   success: Boolean!
 }
 
-input AccountDisableNotificationCategoryInput
-  @join__type(graph: PUBLIC)
-{
-  category: NotificationCategory!
-  channel: NotificationChannel
-}
-
-input AccountDisableNotificationChannelInput
-  @join__type(graph: PUBLIC)
-{
-  channel: NotificationChannel!
-}
-
-input AccountEnableNotificationCategoryInput
-  @join__type(graph: PUBLIC)
-{
-  category: NotificationCategory!
-  channel: NotificationChannel
-}
-
-input AccountEnableNotificationChannelInput
-  @join__type(graph: PUBLIC)
-{
-  channel: NotificationChannel!
-}
-
 enum AccountLevel
   @join__type(graph: PUBLIC)
 {
@@ -142,13 +116,6 @@ input AccountUpdateDisplayCurrencyInput
 }
 
 type AccountUpdateDisplayCurrencyPayload
-  @join__type(graph: PUBLIC)
-{
-  account: ConsumerAccount
-  errors: [Error!]!
-}
-
-type AccountUpdateNotificationSettingsPayload
   @join__type(graph: PUBLIC)
 {
   account: ConsumerAccount
@@ -236,7 +203,7 @@ type Bank
 type BankAccount
   @join__type(graph: PUBLIC)
 {
-  accountNumber: Int!
+  accountNumber: String!
   accountType: String!
   bankBranch: String!
   bankName: String!
@@ -246,7 +213,7 @@ type BankAccount
 input BankAccountInput
   @join__type(graph: PUBLIC)
 {
-  accountNumber: Int!
+  accountNumber: String!
   accountType: String!
   bankBranch: String!
   bankName: String!
@@ -1079,10 +1046,6 @@ type Mutation
   @join__type(graph: PUBLIC)
 {
   accountDelete: AccountDeletePayload!
-  accountDisableNotificationCategory(input: AccountDisableNotificationCategoryInput!): AccountUpdateNotificationSettingsPayload!
-  accountDisableNotificationChannel(input: AccountDisableNotificationChannelInput!): AccountUpdateNotificationSettingsPayload!
-  accountEnableNotificationCategory(input: AccountEnableNotificationCategoryInput!): AccountUpdateNotificationSettingsPayload!
-  accountEnableNotificationChannel(input: AccountEnableNotificationChannelInput!): AccountUpdateNotificationSettingsPayload!
   accountUpdateDefaultWalletId(input: AccountUpdateDefaultWalletIdInput!): AccountUpdateDefaultWalletIdPayload!
   accountUpdateDisplayCurrency(input: AccountUpdateDisplayCurrencyInput!): AccountUpdateDisplayCurrencyPayload!
   businessAccountUpgradeRequest(input: BusinessAccountUpgradeRequestInput!): AccountUpgradePayload!
@@ -1236,12 +1199,6 @@ enum Network
 
 scalar NotificationCategory
   @join__type(graph: PUBLIC)
-
-enum NotificationChannel
-  @join__type(graph: PUBLIC)
-{
-  PUSH @join__enumValue(graph: PUBLIC)
-}
 
 type NotificationChannelSettings
   @join__type(graph: PUBLIC)

--- a/charts/flash/values.yaml
+++ b/charts/flash/values.yaml
@@ -48,16 +48,16 @@ galoy:
       repository: lnflash/flash-app
       imagePullPolicy: Always
       # digests managed by flash-app pipeline in concourse
-      digest: sha256:c052c8568ff0e7e6fc766e5194c19d8b56b8c522d2be87d7a2619faa9e79628b
-      git_ref: "4f6e389"
+      digest: sha256:00c41394b51d4eabfcdf1eb73120fa6812a2e08653085654c07da9fd69b155de
+      git_ref: "7a4af8a"
     websocket:
       repository: docker.io/lnflash/galoy-app-websocket
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:13360c2eb93878308d71faf74753a0260385d0985c28fbe038efbb5221543682"
+      digest: "sha256:3965d7513519fe821ec960d10b3ef24cb9b7adb88eefb33d46e9345c4c6e21fd"
     mongodbMigrate:
       repository: docker.io/lnflash/galoy-app-migrate
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:b6e1788965022d14585d39f336563102576b50ed815195c12aabc784a7fc8c4e"
+      digest: "sha256:31b8c69983fd08d068d457f12e942af0716174b0e972e899d028ee9c7bed80d9"
     mongoBackup:
       repository: us.gcr.io/galoy-org/mongo-backup
       # Currently using Galoy's images. To make changes, see /images & /ci in this repo


### PR DESCRIPTION
# Bump flash image

The flash image will be bumped to digest:
```
sha256:747f640c238725e30ed51ff89590d03e411182c28113a5c5cf6d644131b2de4b
```

The mongodbMigrate image will be bumped to digest:
```
sha256:cb1cb693dbfe94c167a6e3a5e86b7f8f467904eedaafc4f0f3b28db77bc62370
```

The websocket image will be bumped to digest:
```
sha256:a71a75766b92511c0219638a02cbdf606f3c440380a97c0f553163a6e91a3e25
```

Code diff contained in this image:

https://github.com/lnflash/flash/compare/4f6e389...a52917c
