### PR TITLE
chore(deps): bump-flash-image-

### DIFF
--- a/charts/flash/Chart.yaml
+++ b/charts/flash/Chart.yaml
@@ -3,7 +3,7 @@ name: flash
 description: A Helm chart for the Flash application backend
 type: application
 version: 3.2.0
-appVersion: 0.7.41
+appVersion: 0.7.44
 dependencies:
   - name: redis
     repository: https://charts.bitnami.com/bitnami

--- a/charts/flash/Chart.yaml
+++ b/charts/flash/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2 # https://helm.sh/docs/topics/charts/#the-apiversion-field
 name: flash
 description: A Helm chart for the Flash application backend
 type: application
-version: 3.2.0
+version: 3.2.1
 appVersion: 0.7.44
 dependencies:
   - name: redis

--- a/charts/flash/apollo-router/supergraph.graphql
+++ b/charts/flash/apollo-router/supergraph.graphql
@@ -96,6 +96,10 @@ type AccountLimits
   withdrawal: [AccountLimit!]!
 }
 
+"""Bank account number. Accepts String or Int and coerces to String."""
+scalar AccountNumber
+  @join__type(graph: PUBLIC)
+
 input AccountUpdateDefaultWalletIdInput
   @join__type(graph: PUBLIC)
 {
@@ -213,7 +217,7 @@ type BankAccount
 input BankAccountInput
   @join__type(graph: PUBLIC)
 {
-  accountNumber: String!
+  accountNumber: AccountNumber!
   accountType: String!
   bankBranch: String!
   bankName: String!

--- a/charts/flash/values.yaml
+++ b/charts/flash/values.yaml
@@ -48,16 +48,16 @@ galoy:
       repository: lnflash/flash-app
       imagePullPolicy: Always
       # digests managed by flash-app pipeline in concourse
-      digest: sha256:00c41394b51d4eabfcdf1eb73120fa6812a2e08653085654c07da9fd69b155de
-      git_ref: "7a4af8a"
+      digest: sha256:091a6a5cb10b74de81784a3163bb6439aec4ff2c170bf61ff4ba42f97d42020b
+      git_ref: "8109e5d"
     websocket:
       repository: docker.io/lnflash/galoy-app-websocket
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:3965d7513519fe821ec960d10b3ef24cb9b7adb88eefb33d46e9345c4c6e21fd"
+      digest: "sha256:3ccdb840101e1aca058dbaa2e1c04b28cbcd3ddb092ce10d1e4c37fd9ac4950e"
     mongodbMigrate:
       repository: docker.io/lnflash/galoy-app-migrate
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:31b8c69983fd08d068d457f12e942af0716174b0e972e899d028ee9c7bed80d9"
+      digest: "sha256:9447bafdb0b41d03d0fd9679320987dcdb0f7bb9afc6df7794119afc855bdcaf"
     mongoBackup:
       repository: us.gcr.io/galoy-org/mongo-backup
       # Currently using Galoy's images. To make changes, see /images & /ci in this repo


### PR DESCRIPTION
# Bump flash image

The flash image will be bumped to digest:
```
sha256:091a6a5cb10b74de81784a3163bb6439aec4ff2c170bf61ff4ba42f97d42020b
```

The mongodbMigrate image will be bumped to digest:
```
sha256:9447bafdb0b41d03d0fd9679320987dcdb0f7bb9afc6df7794119afc855bdcaf
```

The websocket image will be bumped to digest:
```
sha256:3ccdb840101e1aca058dbaa2e1c04b28cbcd3ddb092ce10d1e4c37fd9ac4950e
```

Code diff contained in this image:

https://github.com/lnflash/flash/compare/7a4af8a...8109e5d
