### PR TITLE
fix(price): inject REDIS_TYPE=standalone when sentinel is disabled

### DIFF
--- a/charts/flash/Chart.yaml
+++ b/charts/flash/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2 # https://helm.sh/docs/topics/charts/#the-apiversion-field
 name: flash
 description: A Helm chart for the Flash application backend
 type: application
-version: 3.2.3
+version: 3.2.4
 appVersion: 0.7.45
 dependencies:
   - name: redis
@@ -21,5 +21,5 @@ dependencies:
     repository: oci://ghcr.io/apollographql/helm-charts
     version: 2.13.0
   - name: price
-    version: 0.5.10
+    version: 0.5.11
     repository: "file://../price"

--- a/charts/price/Chart.yaml
+++ b/charts/price/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: price
 description: A helm chart for real-time and historical BTC price data
 type: application
-version: 0.5.10
+version: 0.5.11
 appVersion: 0.2.1
 
 dependencies:

--- a/charts/price/templates/realtime-deployment.yaml
+++ b/charts/price/templates/realtime-deployment.yaml
@@ -57,6 +57,10 @@ spec:
               secretKeyRef:
                 name: {{ .Values.redis.auth.existingSecret | quote }}
                 key: {{ .Values.redis.auth.existingSecretPasswordKey | quote }}
+          {{- if not .Values.redis.sentinel.enabled }}
+          - name: REDIS_TYPE
+            value: "standalone"
+          {{- end }}
           {{ range until (.Values.redis.replica.replicaCount | int) }}
           - name: {{ printf "REDIS_%d_DNS" . }}
             value: {{ printf "flash-redis-node-%d.flash-redis-headless" . | quote }}


### PR DESCRIPTION
realtime-price server having connection issues to redis:

Problem: Single-node deployments only set REDIS_0_DNS; REDIS_1_DNS and REDIS_2_DNS resolve to the string "undefined" sentinel mode, causing ioredis to report all sentinels unreachable and crash on startup. 

Fix: set REDIS_TYPE to standalone when sentinel is disabled                                      
                                                              