### PR TITLE
chore(deps): bump-flash-image-

### DIFF
--- a/charts/flash/Chart.lock
+++ b/charts/flash/Chart.lock
@@ -16,6 +16,6 @@ dependencies:
   version: 2.13.0
 - name: price
   repository: file://../price
-  version: 0.5.10
-digest: sha256:c758481c5e815f697b9220a8655ada6cdd9ac65eb1a4f357680ba427a960e7e4
-generated: "2026-04-03T10:18:43.405163617-05:00"
+  version: 0.5.11
+digest: sha256:5f7c5e1cfd1ce6f75faf6a9deefc6a4c95c6585cdcd642f5e484d2c1fb2096bc
+generated: "2026-05-12T13:46:52.087762963-05:00"

--- a/charts/flash/Chart.yaml
+++ b/charts/flash/Chart.yaml
@@ -3,7 +3,7 @@ name: flash
 description: A Helm chart for the Flash application backend
 type: application
 version: 3.2.5
-appVersion: 0.7.50
+appVersion: 0.7.51
 dependencies:
   - name: redis
     repository: https://charts.bitnami.com/bitnami

--- a/charts/flash/Chart.yaml
+++ b/charts/flash/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2 # https://helm.sh/docs/topics/charts/#the-apiversion-field
 name: flash
 description: A Helm chart for the Flash application backend
 type: application
-version: 3.2.5
+version: 3.2.6
 appVersion: 0.7.51
 dependencies:
   - name: redis

--- a/charts/flash/values.yaml
+++ b/charts/flash/values.yaml
@@ -48,16 +48,16 @@ galoy:
       repository: lnflash/flash-app
       imagePullPolicy: Always
       # digests managed by flash-app pipeline in concourse
-      digest: sha256:fafe6db6763439fe2fb2c1f6e7c5613deba00d964e96b1afec4e72528c522526
-      git_ref: "5bf712b"
+      digest: sha256:1e5de0942a470312741a9a052b53803e8d7dff1164b84255af2cd5c5e809d364
+      git_ref: "65bc3d0"
     websocket:
       repository: docker.io/lnflash/galoy-app-websocket
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:1b4edc0be79cb9eec1159b37390476e02af688dec58c85b5b156ee51d83dec45"
+      digest: "sha256:a1268be37966df663d6e69538bc5304dac5f91ee5308355989889beeee7e366b"
     mongodbMigrate:
       repository: docker.io/lnflash/galoy-app-migrate
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:7035335096cce7c8d26e067da3a4c23efa4c22671f9e0d3b79a250ced4cb74f2"
+      digest: "sha256:7c9c417ad55029c4c4f8943c2ac2669fe7ae04368bfe9cd49cd628b4222f8d47"
     mongoBackup:
       repository: us.gcr.io/galoy-org/mongo-backup
       # Currently using Galoy's images. To make changes, see /images & /ci in this repo


### PR DESCRIPTION
# Bump flash image

The flash image will be bumped to digest:
```
sha256:1e5de0942a470312741a9a052b53803e8d7dff1164b84255af2cd5c5e809d364
```

The mongodbMigrate image will be bumped to digest:
```
sha256:7c9c417ad55029c4c4f8943c2ac2669fe7ae04368bfe9cd49cd628b4222f8d47
```

The websocket image will be bumped to digest:
```
sha256:a1268be37966df663d6e69538bc5304dac5f91ee5308355989889beeee7e366b
```

Code diff contained in this image:

https://github.com/lnflash/flash/compare/5bf712b...65bc3d0
