### PR TITLE
chore(deps): bump-flash-image-

### DIFF
--- a/charts/flash/Chart.yaml
+++ b/charts/flash/Chart.yaml
@@ -3,7 +3,7 @@ name: flash
 description: A Helm chart for the Flash application backend
 type: application
 version: 3.2.6
-appVersion: 0.7.51
+appVersion: 0.8.0
 dependencies:
   - name: redis
     repository: https://charts.bitnami.com/bitnami

--- a/charts/flash/Chart.yaml
+++ b/charts/flash/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2 # https://helm.sh/docs/topics/charts/#the-apiversion-field
 name: flash
 description: A Helm chart for the Flash application backend
 type: application
-version: 3.2.6
+version: 3.2.7
 appVersion: 0.8.0
 dependencies:
   - name: redis

--- a/charts/flash/apollo-router/supergraph.graphql
+++ b/charts/flash/apollo-router/supergraph.graphql
@@ -240,19 +240,17 @@ type Bank
 type BankAccount
   @join__type(graph: PUBLIC)
 {
-  accountName: String!
+  accountName: String
   accountNumber: String!
   accountType: String!
-
-  """Name of the bank institution"""
-  bank: String!
-  branchCode: String!
+  bankBranch: String!
+  bankName: String!
 
   """Account currency (e.g. JMD, USD)"""
   currency: String!
 
   """ERPNext bank account identifier"""
-  id: ID!
+  id: ID
   isDefault: Boolean!
 }
 

--- a/charts/flash/values.yaml
+++ b/charts/flash/values.yaml
@@ -48,16 +48,16 @@ galoy:
       repository: lnflash/flash-app
       imagePullPolicy: Always
       # digests managed by flash-app pipeline in concourse
-      digest: sha256:1e5de0942a470312741a9a052b53803e8d7dff1164b84255af2cd5c5e809d364
-      git_ref: "65bc3d0"
+      digest: sha256:b1d1c0e252fce737427010ef74b5a257d216c66282340aa2ced2794be5381790
+      git_ref: "5ef35a5"
     websocket:
       repository: docker.io/lnflash/galoy-app-websocket
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:a1268be37966df663d6e69538bc5304dac5f91ee5308355989889beeee7e366b"
+      digest: "sha256:2a1b9464a4c9064c6c41ecfd031d892fe4d68f85a48930e73df915dcf3bfdd9c"
     mongodbMigrate:
       repository: docker.io/lnflash/galoy-app-migrate
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:7c9c417ad55029c4c4f8943c2ac2669fe7ae04368bfe9cd49cd628b4222f8d47"
+      digest: "sha256:c9a918fcbcc1dbd2dcf95cb14d0aeeb16bf525b84ca3ebf1718fd4159104d48a"
     mongoBackup:
       repository: us.gcr.io/galoy-org/mongo-backup
       # Currently using Galoy's images. To make changes, see /images & /ci in this repo


### PR DESCRIPTION
# Bump flash image

The flash image will be bumped to digest:
```
sha256:b1d1c0e252fce737427010ef74b5a257d216c66282340aa2ced2794be5381790
```

The mongodbMigrate image will be bumped to digest:
```
sha256:c9a918fcbcc1dbd2dcf95cb14d0aeeb16bf525b84ca3ebf1718fd4159104d48a
```

The websocket image will be bumped to digest:
```
sha256:2a1b9464a4c9064c6c41ecfd031d892fe4d68f85a48930e73df915dcf3bfdd9c
```

Code diff contained in this image:

https://github.com/lnflash/flash/compare/65bc3d0...5ef35a5
