### PR TITLE
chore(deps): bump-flash-image-

### DIFF
--- a/charts/flash/Chart.yaml
+++ b/charts/flash/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2 # https://helm.sh/docs/topics/charts/#the-apiversion-field
 name: flash
 description: A Helm chart for the Flash application backend
 type: application
-version: 3.2.9
+version: 3.2.10
 appVersion: 0.8.3
 dependencies:
   - name: redis

--- a/charts/flash/Chart.yaml
+++ b/charts/flash/Chart.yaml
@@ -3,7 +3,7 @@ name: flash
 description: A Helm chart for the Flash application backend
 type: application
 version: 3.2.9
-appVersion: 0.8.2
+appVersion: 0.8.3
 dependencies:
   - name: redis
     repository: https://charts.bitnami.com/bitnami

--- a/charts/flash/values.yaml
+++ b/charts/flash/values.yaml
@@ -36,9 +36,9 @@ galoy:
         from:
         subject: "New Cashout"
     ibex:
-      url:
-      email:
-      password:
+      clientId:
+      clientSecret:
+      environment: "sandbox"
       webhook:
         uri:
         port: 4008
@@ -482,9 +482,9 @@ secrets:
   ## Secrets for DO Spaces
   doSpacesAccessKey:
   doSpacesSecretKey:
-  ## secret for Ibex webhook authentication
-  ibexEmail:
-  ibexPassword:
+  ## secret for Ibex authentication
+  ibexClientId:
+  ibexClientSecret:
   ibexWebhookKey:
 ## Tracing details
 ##

--- a/charts/flash/values.yaml
+++ b/charts/flash/values.yaml
@@ -48,16 +48,16 @@ galoy:
       repository: lnflash/flash-app
       imagePullPolicy: Always
       # digests managed by flash-app pipeline in concourse
-      digest: sha256:01e58c464cc45009212f72698c8aa2ef4d5ff410a39c00ecfbc10eb6f66ead36
-      git_ref: "ad71fd5"
+      digest: sha256:acdf3c5643bc344ed252b44ec3c5a30321d251538e67ada381959e8273c7974b
+      git_ref: "32d7cab"
     websocket:
       repository: docker.io/lnflash/galoy-app-websocket
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:ac14c96e3ee5a1484f6d6cb95b2361f00dd61ca57b7369abb54e91ed601a45ee"
+      digest: "sha256:e8104f3fc37131a1cdd504cf8249defbf17efc7025d759e129ee4fb42132fc62"
     mongodbMigrate:
       repository: docker.io/lnflash/galoy-app-migrate
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:a78bcddc307135f616653c796eae03b80d0d22b7e8ccab2644ddab9d22bbe2fa"
+      digest: "sha256:c98109394cd9e8b7f6d2cea7f0c219a62a66584822de3600ee4ece981c814f73"
     mongoBackup:
       repository: us.gcr.io/galoy-org/mongo-backup
       # Currently using Galoy's images. To make changes, see /images & /ci in this repo


### PR DESCRIPTION
# Bump flash image

The flash image will be bumped to digest:
```
sha256:acdf3c5643bc344ed252b44ec3c5a30321d251538e67ada381959e8273c7974b
```

The mongodbMigrate image will be bumped to digest:
```
sha256:c98109394cd9e8b7f6d2cea7f0c219a62a66584822de3600ee4ece981c814f73
```

The websocket image will be bumped to digest:
```
sha256:e8104f3fc37131a1cdd504cf8249defbf17efc7025d759e129ee4fb42132fc62
```

Code diff contained in this image:

https://github.com/lnflash/flash/compare/ad71fd5...32d7cab
