### PR TITLE
chore(deps): bump-flash-image-

### DIFF
--- a/charts/flash/Chart.yaml
+++ b/charts/flash/Chart.yaml
@@ -3,7 +3,7 @@ name: flash
 description: A Helm chart for the Flash application backend
 type: application
 version: 3.2.11
-appVersion: 0.8.3
+appVersion: 0.8.5
 dependencies:
   - name: redis
     repository: https://charts.bitnami.com/bitnami

--- a/charts/flash/values.yaml
+++ b/charts/flash/values.yaml
@@ -48,16 +48,16 @@ galoy:
       repository: lnflash/flash-app
       imagePullPolicy: Always
       # digests managed by flash-app pipeline in concourse
-      digest: sha256:acdf3c5643bc344ed252b44ec3c5a30321d251538e67ada381959e8273c7974b
-      git_ref: "32d7cab"
+      digest: sha256:1b5b535388f63b67033d3fcf7510150b1deb7dddde23b7e964f65e2353975af3
+      git_ref: "03f3350"
     websocket:
       repository: docker.io/lnflash/galoy-app-websocket
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:e8104f3fc37131a1cdd504cf8249defbf17efc7025d759e129ee4fb42132fc62"
+      digest: "sha256:f2bfcf82b4d0aa5141adc3e904ecdeaacfc61dd01e3761092c59002618ff55b9"
     mongodbMigrate:
       repository: docker.io/lnflash/galoy-app-migrate
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:c98109394cd9e8b7f6d2cea7f0c219a62a66584822de3600ee4ece981c814f73"
+      digest: "sha256:f09aeb4ecf85ccb7c883622d9df3f788c8698c81b6abcc37348016430197cc47"
     mongoBackup:
       repository: us.gcr.io/galoy-org/mongo-backup
       # Currently using Galoy's images. To make changes, see /images & /ci in this repo


### PR DESCRIPTION
# Bump flash image

The flash image will be bumped to digest:
```
sha256:d5a31ce6a6abb3c337fe71c678c4d8f3f3f78d0416b400a1e8f7cf2a4a54feb7
```

The mongodbMigrate image will be bumped to digest:
```
sha256:58a2611ecf847a1ce63fb5c5c241ae3651c3e6c53f11041086d462931bf56ab5
```

The websocket image will be bumped to digest:
```
sha256:8c54843cd670f865cfb5e72dbf85dd99f4000523374c5c38abce5887e3dfb21f
```

Code diff contained in this image:

https://github.com/lnflash/flash/compare/32d7cab...d4a3717
