### PR TITLE
chore(deps): bump-flash-image-

### DIFF
--- a/charts/flash/Chart.yaml
+++ b/charts/flash/Chart.yaml
@@ -3,7 +3,7 @@ name: flash
 description: A Helm chart for the Flash application backend
 type: application
 version: 3.2.11
-appVersion: 0.8.3
+appVersion: 0.8.10
 dependencies:
   - name: redis
     repository: https://charts.bitnami.com/bitnami

--- a/charts/flash/values.yaml
+++ b/charts/flash/values.yaml
@@ -48,16 +48,16 @@ galoy:
       repository: lnflash/flash-app
       imagePullPolicy: Always
       # digests managed by flash-app pipeline in concourse
-      digest: sha256:acdf3c5643bc344ed252b44ec3c5a30321d251538e67ada381959e8273c7974b
-      git_ref: "32d7cab"
+      digest: sha256:8c30df7d0bd74d3a180fcae61c03433a7ffa36c8d764336a48396b37237e6383
+      git_ref: "1e50e3c"
     websocket:
       repository: docker.io/lnflash/galoy-app-websocket
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:e8104f3fc37131a1cdd504cf8249defbf17efc7025d759e129ee4fb42132fc62"
+      digest: "sha256:9c38bf76862dbe7cdb3d2d5fddd0c721668c3a2e409e060c0d62c077fe40d609"
     mongodbMigrate:
       repository: docker.io/lnflash/galoy-app-migrate
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:c98109394cd9e8b7f6d2cea7f0c219a62a66584822de3600ee4ece981c814f73"
+      digest: "sha256:9646241996e5cef85dd0cfad48ff80ce466a12e21ea86b6f67169272e904ea6f"
     mongoBackup:
       repository: us.gcr.io/galoy-org/mongo-backup
       # Currently using Galoy's images. To make changes, see /images & /ci in this repo


### PR DESCRIPTION
# Bump flash image

The flash image will be bumped to digest:
```
sha256:2814900a148ff413bf1c5e634680181ddeb6e9a0704d0285dc9a23303826b8d4
```

The mongodbMigrate image will be bumped to digest:
```
sha256:3c5b6cab826b9aa5901bed659025c609f9b11bef0f448969b127ce2dd1222f17
```

The websocket image will be bumped to digest:
```
sha256:955e61877b5dea15dccc6b5fc14e3918d3538f7eec3fd9d7928e8b75d11e5802
```

Code diff contained in this image:

https://github.com/lnflash/flash/compare/32d7cab...d190f03
