### PR TITLE
chore(deps): bump-flash-image-

### DIFF
--- a/charts/flash/Chart.yaml
+++ b/charts/flash/Chart.yaml
@@ -3,7 +3,7 @@ name: flash
 description: A Helm chart for the Flash application backend
 type: application
 version: 3.2.11
-appVersion: 0.8.3
+appVersion: 0.8.12
 dependencies:
   - name: redis
     repository: https://charts.bitnami.com/bitnami

--- a/charts/flash/values.yaml
+++ b/charts/flash/values.yaml
@@ -48,16 +48,16 @@ galoy:
       repository: lnflash/flash-app
       imagePullPolicy: Always
       # digests managed by flash-app pipeline in concourse
-      digest: sha256:acdf3c5643bc344ed252b44ec3c5a30321d251538e67ada381959e8273c7974b
-      git_ref: "32d7cab"
+      digest: sha256:fb0309364e605a34b692fae9cdca24185b4426fb1216af37543b67b14d4e608c
+      git_ref: "b3ad107"
     websocket:
       repository: docker.io/lnflash/galoy-app-websocket
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:e8104f3fc37131a1cdd504cf8249defbf17efc7025d759e129ee4fb42132fc62"
+      digest: "sha256:432fa240c573d171b1815b7177d71babaa02943d9429799813de34946eb59f91"
     mongodbMigrate:
       repository: docker.io/lnflash/galoy-app-migrate
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:c98109394cd9e8b7f6d2cea7f0c219a62a66584822de3600ee4ece981c814f73"
+      digest: "sha256:3ff3af72003717f253343f14fe1015593744eeae5b77ed9a294c886f84af025f"
     mongoBackup:
       repository: us.gcr.io/galoy-org/mongo-backup
       # Currently using Galoy's images. To make changes, see /images & /ci in this repo


### PR DESCRIPTION
# Bump flash image

The flash image will be bumped to digest:
```
sha256:2978a364318bd4029163f8615a5fd2073986652efccdfaa1bd2cabb33fed3030
```

The mongodbMigrate image will be bumped to digest:
```
sha256:898760873558ed7ac0b3e8cd33238f607b6124e709b3732c85142070f104f1f2
```

The websocket image will be bumped to digest:
```
sha256:cf3aed88165a4cee6fa1e2e0c254024952d4573522c778d04fce477474fc2c1a
```

Code diff contained in this image:

https://github.com/lnflash/flash/compare/32d7cab...a795d08
