### PR TITLE
fix(flash): default cashout.enabled to false (flags-off baseline)

### DIFF
--- a/charts/flash/values.yaml
+++ b/charts/flash/values.yaml
@@ -22,7 +22,7 @@ galoy:
           bid:
           ask:
     cashout:
-      enabled: true
+      enabled: false # flags-off baseline; enable per environment via overrides
       skipPayment: true
       minimum:
         amount: 0


### PR DESCRIPTION
## Summary
Flip the flash chart's `cashout.enabled` default from `true` back to `false`.

lnflash/charts#188 (smoketest repair) restored the flash chart `values.yaml` with `cashout.enabled: true`. It's **masked in test/prod** — the deployments overlays (tf-module template + env values, per lnflash/deployments#46) force `cashout.enabled: false` — so nothing is broken today. But the chart *default* should match the flags-off launch posture so a new or incomplete environment overlay can't accidentally ship cashout enabled.

Aligns the chart default with the api's `dev/config/base-config.yaml` (lnflash/flash#425) and the deployments config (#46), where bridge/topup/cashout are all off by default.

No deploy impact in existing environments (overridden downstream); YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)