### PR TITLE
fix(smoketest): derive flash image digests from chart values

### DIFF
--- a/.github/workflows/dev-smoketest.yaml
+++ b/.github/workflows/dev-smoketest.yaml
@@ -145,6 +145,24 @@ jobs:
           for resource in $(kubectl -n galoy-dev-nostr get deployment,statefulset -o name); do
             kubectl -n galoy-dev-nostr rollout status "$resource" --timeout=5m
           done
+      - name: Diagnostics on workload failure
+        if: failure()
+        run: |
+          for ns in galoy-dev-galoy galoy-dev-nostr; do
+            echo "::group::[$ns] pods"
+            kubectl -n "$ns" get pods -o wide || true
+            echo "::endgroup::"
+            # Describe + logs for any pod not Running/Completed (the culprits).
+            for pod in $(kubectl -n "$ns" get pods -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.phase}{"\n"}{end}' 2>/dev/null | awk '$2!="Running" && $2!="Succeeded" {print $1}'); do
+              echo "::group::[$ns/$pod] describe"
+              kubectl -n "$ns" describe pod "$pod" || true
+              echo "::endgroup::"
+              echo "::group::[$ns/$pod] logs (current + previous)"
+              kubectl -n "$ns" logs "$pod" --all-containers --tail=200 || true
+              kubectl -n "$ns" logs "$pod" --all-containers --previous --tail=200 2>/dev/null || true
+              echo "::endgroup::"
+            done
+          done
       - name: Flash API Smoketest
         timeout-minutes: 10
         run: |

--- a/.github/workflows/dev-smoketest.yaml
+++ b/.github/workflows/dev-smoketest.yaml
@@ -85,7 +85,13 @@ jobs:
             docker_host="unix:///Users/dread/.docker/run/docker.sock"
           fi
           docker_config="$(mktemp -d)"
-          printf '{"auths":{}}\n' > "$docker_config/config.json"
+          # Give Docker an explicit empty (anonymous) auth entry for Docker Hub
+          # and no credential store, so it never invokes the macOS keychain
+          # helper. On the self-hosted Mac runner, Docker Desktop consults the
+          # osxkeychain helper for docker.io even with an empty config; the
+          # helper can't run in the headless CI session ("keychain cannot be
+          # accessed"), failing every pull of an uncached (public) image.
+          printf '{"auths":{"https://index.docker.io/v1/":{"auth":""}},"credsStore":"","credHelpers":{}}\n' > "$docker_config/config.json"
           trap 'rm -rf "$docker_config"' EXIT
           docker_cmd() {
             if [ -n "$docker_host" ]; then

--- a/.github/workflows/dev-smoketest.yaml
+++ b/.github/workflows/dev-smoketest.yaml
@@ -36,6 +36,28 @@ jobs:
             --k3s-arg --disable=servicelb@server:0
       - name: Mirror Docker Hub Images
         run: |
+          # Flash-family image digests come from the chart values, not a
+          # hardcoded list. docker.io is redirected to the local k3d registry,
+          # which only holds images imported below — so a stale hardcoded digest
+          # silently breaks EVERY image bump (the new digest isn't in the local
+          # registry, pods ImagePullBackOff, workloads never become ready).
+          # Deriving them from charts/flash/{,-pay/}values.yaml keeps the
+          # smoketest importing exactly the images the chart references.
+          flash_digest() {
+            awk -v key="    $1:" '
+              index($0, key)==1 { infix=1; next }
+              infix && /digest:/ { match($0, /sha256:[a-f0-9]+/); if (RSTART>0) { print substr($0, RSTART, RLENGTH); exit } }
+              infix && /^    [a-zA-Z]/ { exit }
+            ' charts/flash/values.yaml
+          }
+          flash_app_digest="$(flash_digest app)"
+          flash_ws_digest="$(flash_digest websocket)"
+          flash_migrate_digest="$(flash_digest mongodbMigrate)"
+          flash_pay_digest="$(grep -A3 '^image:' charts/flash-pay/values.yaml | grep -m1 digest | grep -oE 'sha256:[a-f0-9]+')"
+          for d in "$flash_app_digest" "$flash_ws_digest" "$flash_migrate_digest" "$flash_pay_digest"; do
+            if [ -z "$d" ]; then echo "ERROR: could not read a flash image digest from chart values" >&2; exit 1; fi
+          done
+          echo "flash image digests: app=$flash_app_digest ws=$flash_ws_digest migrate=$flash_migrate_digest pay=$flash_pay_digest"
           images=(
             docker.io/bitnamilegacy/mongodb:7.0.9-debian-12-r4
             docker.io/bitnamilegacy/postgresql:16.4.0-debian-12-r14
@@ -44,10 +66,10 @@ jobs:
             docker.io/bitnamilegacy/redis-sentinel:7.2.1-debian-11-r0
             docker.io/groundnuty/k8s-wait-for:v1.5.1
             docker.io/dockurr/strfry@sha256:df140472554e5a0b5bbe08ec417805d283098621833e44827d8018c98b74243d
-            docker.io/lnflash/flash-app@sha256:acdf3c5643bc344ed252b44ec3c5a30321d251538e67ada381959e8273c7974b
-            docker.io/lnflash/flash-pay@sha256:a910ae53ce13159f0c4f52b7aae35445a50fba94e3b702b279cfa58eb4e41486
-            docker.io/lnflash/galoy-app-migrate@sha256:c98109394cd9e8b7f6d2cea7f0c219a62a66584822de3600ee4ece981c814f73
-            docker.io/lnflash/galoy-app-websocket@sha256:e8104f3fc37131a1cdd504cf8249defbf17efc7025d759e129ee4fb42132fc62
+            "docker.io/lnflash/flash-app@${flash_app_digest}"
+            "docker.io/lnflash/flash-pay@${flash_pay_digest}"
+            "docker.io/lnflash/galoy-app-migrate@${flash_migrate_digest}"
+            "docker.io/lnflash/galoy-app-websocket@${flash_ws_digest}"
             docker.io/lnflash/nostr-multiplexer@sha256:1b7baadaef4b78fc0d2d79b297f6f725fe47130fad590222a1c19b7be96a5c8b
             docker.io/lnflash/price@sha256:8f6422c3a762ee5badf7d5014652c00b19c3d357db4566a972c62d23130422e9
             docker.io/lnflash/price-history@sha256:916de25989444b317a2704a80a90fcda1af9899feba970daa2db1cc63e8f7159

--- a/charts/flash/values.yaml
+++ b/charts/flash/values.yaml
@@ -45,6 +45,25 @@ galoy:
         uri:
         port: 4008
         secret: "not-so-secret"
+    # `bridge` is a REQUIRED config section for the flash app image (see the
+    # api config schema, src/config/schema.ts). The dev config previously
+    # lacked it, so every config-loading server (api/websocket/trigger/
+    # ibex-webhook/exporter) crash-looped on schema validation once the image
+    # started requiring it. Disabled baseline; real values injected/overridden
+    # per environment (deployments overlays).
+    bridge:
+      enabled: false
+      apiKey: ""
+      baseUrl: "https://api.sandbox.bridge.xyz/v0"
+      developerFeePercent: 2.0
+      webhook:
+        port: 4009
+        timestampSkewMs: 300000
+        publicKeys:
+          kyc: "<replace>"
+          deposit: "<replace>"
+          transfer: "<replace>"
+          external_account: "<replace>"
   images:
     app:
       repository: lnflash/flash-app


### PR DESCRIPTION
## Problem
The dev-smoketest imports a **hardcoded** list of image digests into a local k3d registry that `docker.io` is redirected to. So every image-bump PR fails: the bumped chart references **new** digests that aren't in the local registry → pods `ImagePullBackOff` → workloads never become ready ("progress deadline exceeded"). #188 fixed the k3d/terraform layer, which is why this next-layer flaw only surfaced now (on #196, the first bridge image bump to get past k3d setup).

This means the smoketest, as written, can **never** validate a new image — it structurally blocks all image bumps.

## Fix
Read the flash-family digests (`flash-app`, `galoy-app-websocket`, `galoy-app-migrate`, `flash-pay`) from `charts/flash/values.yaml` and `charts/flash-pay/values.yaml` at runtime, so the smoketest always imports exactly the images the chart references. Third-party (bitnami/kratos/oathkeeper/strfry) and price/nostr images stay pinned — they don't move with flash image builds.

Dependency-free (awk/grep, no yq needed on the runner); fails fast if a digest can't be read. Extraction verified against the current chart values; workflow YAML and shell (`bash -n`) validated.

Unblocks #196 (and all future image bumps) so the smoketest actually deploys and validates the new image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)