### PR TITLE
fix(flash): drop stale IBEX_EMAIL/IBEX_PASSWORD env injection (chart 3.2.13)

### DIFF
--- a/charts/flash/Chart.yaml
+++ b/charts/flash/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2 # https://helm.sh/docs/topics/charts/#the-apiversion-field
 name: flash
 description: A Helm chart for the Flash application backend
 type: application
-version: 3.2.12
+version: 3.2.13
 appVersion: 0.9.2
 dependencies:
   - name: redis

--- a/charts/flash/templates/_helpers.tpl
+++ b/charts/flash/templates/_helpers.tpl
@@ -237,16 +237,13 @@ Define kratos env vars
 {{- define "galoy.ibex.env" -}}
 - name: IBEX_URL
   value: {{ .Values.galoy.ibex.url | quote }}
-- name: IBEX_EMAIL
-  valueFrom:
-    secretKeyRef:
-      name: {{ .Values.galoy.ibex.authExistingSecret.name | quote }}
-      key: {{ .Values.galoy.ibex.authExistingSecret.email_key | quote }}
-- name: IBEX_PASSWORD
-  valueFrom:
-    secretKeyRef:
-      name: {{ .Values.galoy.ibex.authExistingSecret.name | quote }}
-      key: {{ .Values.galoy.ibex.authExistingSecret.password_key | quote }}
+{{/*
+  IBEX_EMAIL / IBEX_PASSWORD were removed: the app reads IBEX credentials from
+  the config file (ibex.clientId / ibex.clientSecret in custom.yaml), not env,
+  and the ibex-auth secret was migrated to client-id/client-secret keys — the
+  old api-email/api-password keys no longer exist, so referencing them made
+  kubelet fail every pod with CreateContainerConfigError.
+*/}}
 - name: IBEX_LISTENER_HOST
   value: {{ .Values.galoy.ibex.listenerHost | quote }}
 - name: IBEX_WEBHOOK_SECRET

--- a/charts/flash/values.yaml
+++ b/charts/flash/values.yaml
@@ -120,8 +120,9 @@ galoy:
     listenerHost:
     authExistingSecret:
       name: ibex-auth
-      email_key: api-email
-      password_key: api-password
+      # email_key/password_key removed — the secret's api-email/api-password
+      # keys are gone (migrated to client-id/client-secret, consumed via the
+      # config file, not env). Only the webhook secret is still env-injected.
       webhook_secret_key: webhook-secret
     webhook:
       nameOverride:


### PR DESCRIPTION
## Problem
The 3.2.12 rollout in TEST failed with every config-consuming workload (api, websocket, trigger, exporter, ibex-webhook) stuck in `CreateContainerConfigError`:

```
Error: couldn't find key api-email in Secret flash/ibex-auth
```

## Cause
The `galoy.ibex.env` helper (included by all six workloads incl. the cronjob) injects `IBEX_EMAIL`/`IBEX_PASSWORD` from the `ibex-auth` secret's `api-email`/`api-password` keys. The deployments repo migrated that secret to `client-id`/`client-secret` — and the app now reads IBEX credentials exclusively from the config file (`ibex.clientId`/`clientSecret`); `grep -r "IBEX_EMAIL\|IBEX_PASSWORD\|IBEX_CLIENT" src/` in the flash repo returns nothing. The env injection is dead code that now references nonexistent secret keys, which makes kubelet refuse to create the containers.

## Fix
- Remove the `IBEX_EMAIL`/`IBEX_PASSWORD` entries from the helper (and the now-unused `email_key`/`password_key` values defaults).
- Keep `IBEX_URL`, `IBEX_LISTENER_HOST`, and `IBEX_WEBHOOK_SECRET` (the `webhook-secret` key still exists in the secret).
- Bump chart version to **3.2.13** so the publish workflow ships it and opens the deployments pin PR.

## Testing
- dev-smoketest deploys the chart end-to-end (this is a strict reduction in secret-key requirements, so the dev ibex-auth secret still satisfies it).
- After merge + publish + pin bump: `make flash ENV=test` should roll the six stuck workloads to Running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)