### PR TITLE
fix(publish): resolve price subchart deps before packaging flash (chart 3.2.14)

### DIFF
--- a/.github/workflows/publish-flash-chart.yaml
+++ b/.github/workflows/publish-flash-chart.yaml
@@ -62,6 +62,12 @@ jobs:
           echo "${GHCR_TOKEN}" | helm registry login ghcr.io -u "${{ github.actor }}" --password-stdin
           # The flash chart has a local `file://../price` dependency, so build
           # deps from the repo root (all sibling charts are present here).
+          # CRITICAL: resolve price's OWN deps first — helm does not recurse
+          # into file:// subcharts, and charts/price/charts/ is gitignored, so
+          # skipping this silently packages price WITHOUT its bundled bitnami
+          # postgresql; the next `helm upgrade` then PRUNES the live
+          # price-history postgres StatefulSet/Service from the cluster.
+          helm dependency update charts/price
           helm dependency update charts/flash
           helm package charts/flash
           # `already exists` is not an error — an unchanged version is a no-op.

--- a/charts/flash/Chart.yaml
+++ b/charts/flash/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2 # https://helm.sh/docs/topics/charts/#the-apiversion-field
 name: flash
 description: A Helm chart for the Flash application backend
 type: application
-version: 3.2.13
+version: 3.2.14
 appVersion: 0.9.2
 dependencies:
   - name: redis

--- a/package-releases.sh
+++ b/package-releases.sh
@@ -27,6 +27,13 @@ fi
 
 for chart in "${CHARTS[@]}"; do
   echo "Processing $chart..."
+  # flash bundles price via file://../price, but helm does not recurse into a
+  # local subchart's own dependencies (and charts/price/charts/ is gitignored).
+  # Without this, flash packages price WITHOUT its bitnami postgresql and the
+  # next helm upgrade prunes the live price-history postgres from the cluster.
+  if [ "$chart" = "flash" ]; then
+    helm dependency update "charts/price"
+  fi
   helm dependency update "charts/$chart"
   helm package "charts/$chart"
 


### PR DESCRIPTION
## Problem
`flash-price-history-db` (the price subchart's bundled bitnami postgresql) is **gone from the TEST cluster** — every `flash-price-history-postgres-migrate-*` job fails with `getaddrinfo ENOTFOUND flash-price-history-db`. Job history shows this started ~46 days ago (rev 93 Complete → rev 94 Failed) and persists through 3.2.12/3.2.13. The data PVC (`data-flash-price-history-db-0`, 697d, retain class) survived.

## Cause
- `charts/price/Chart.yaml` declares bitnami `postgresql` as a dependency; `charts/price/.gitignore` ignores `charts/`, so the tarball is never in git.
- The flash chart bundles price via `file://../price`, and `helm dependency update charts/flash` does **not** recurse into a local subchart's own dependencies.
- Result: on any clean checkout, the packaged flash chart ships price **without postgresql**, and the next `helm upgrade` silently prunes the live StatefulSet + Service. (Intermittent history = machines with leftover `price/charts/` packaged working charts; clean checkouts packaged broken ones.)

## Fix
- `helm dependency update charts/price` before packaging flash — in **both** `publish-flash-chart.yaml` and `package-releases.sh`.
- Chart bumped to **3.2.14** so a correctly-packaged chart ships through the pipeline.

## Recovery expectation
Applying 3.2.14 re-creates StatefulSet `flash-price-history-db` under its original name; its volumeClaimTemplate (`data-…-0`) rebinds the existing PVC — **historical price data intact**. The next `flash-price-history-postgres-migrate-<rev>` job should then complete for the first time in ~46 days.

🤖 Generated with [Claude Code](https://claude.com/claude-code)