### PR TITLE
fix(flash): pass -c flag for cronjob configPath (chart 3.2.15)

### DIFF
--- a/charts/flash/Chart.yaml
+++ b/charts/flash/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2 # https://helm.sh/docs/topics/charts/#the-apiversion-field
 name: flash
 description: A Helm chart for the Flash application backend
 type: application
-version: 3.2.14
+version: 3.2.15
 appVersion: 0.9.2
 dependencies:
   - name: redis

--- a/charts/flash/templates/galoy-cronjob.yaml
+++ b/charts/flash/templates/galoy-cronjob.yaml
@@ -37,6 +37,7 @@ spec:
             - "-r"
             - "/app/lib/services/tracing.js"
             - "lib/servers/cron.js"
+            - "-c"
             - "/var/yaml/custom.yaml"
             resources:
               {{ toYaml .Values.galoy.galoyCron.resources | nindent 14 }}


### PR DESCRIPTION
## Problem
`flash-cronjob` pods crash-loop on every scheduled firing:
```
Missing required argument: configPath
```

## Cause
`galoy-cronjob.yaml` passes `"/var/yaml/custom.yaml"` as a bare positional arg to `lib/servers/cron.js`, but the entrypoint requires it via the `-c`/`--configPath` flag — exactly how api/websocket/trigger already pass it. The `custom-yaml` secret mount was already correctly wired; only the flag was missing.

## Fix
Insert `- "-c"` before the path. Chart bumped to **3.2.15**.

## Verification
After the pipeline ships this and it's applied: the next scheduled `flash-cronjob-*` pod should run to `Completed` instead of CrashLoopBackOff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)