### PR TITLE
chore(deps): bump-flash-image-

### DIFF
--- a/charts/flash/Chart.yaml
+++ b/charts/flash/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2 # https://helm.sh/docs/topics/charts/#the-apiversion-field
 name: flash
 description: A Helm chart for the Flash application backend
 type: application
-version: 3.2.15
-appVersion: 0.9.2
+version: 3.2.16
+appVersion: 0.9.3
 dependencies:
   - name: redis
     repository: https://charts.bitnami.com/bitnami

--- a/charts/flash/apollo-router/supergraph.graphql
+++ b/charts/flash/apollo-router/supergraph.graphql
@@ -797,7 +797,18 @@ Provides global settings for the application which might have an impact for the 
 type Globals
   @join__type(graph: PUBLIC)
 {
+  """
+  Whether Bridge (international bank transfer) entry points
+  should be shown to the user. Controlled by the instance-wide bridge feature flag.
+  """
+  bridgeEnabled: Boolean!
   buildInformation: BuildInformation!
+
+  """
+  Whether cashout (settle to local bank account) entry points
+  should be shown to the user. Controlled by the instance-wide cashout feature flag.
+  """
+  cashoutEnabled: Boolean!
   feesInformation: FeesInformation!
 
   """

--- a/charts/flash/values.yaml
+++ b/charts/flash/values.yaml
@@ -16,6 +16,15 @@ galoy:
       coldStorage:
         walletName: cold
         hotToColdRebalanceQueueName: dev
+    # Flash is IBEX-custodial: no LND nodes, no cold-wallet rebalance, no swap
+    # outs. lndTasksEnabled gates the upstream-galoy LND maintenance tasks in
+    # the cron server (app image >= the #430 schema; older images reject the
+    # key). With all three off, the daily cron runs only mongo expiry cleanup
+    # and Bridge<->IBEX reconciliation.
+    cronConfig:
+      rebalanceEnabled: false
+      swapEnabled: false
+      lndTasksEnabled: false
     exchangeRates:
       USD:
         JMD:

--- a/charts/flash/values.yaml
+++ b/charts/flash/values.yaml
@@ -69,16 +69,16 @@ galoy:
       repository: lnflash/flash-app
       imagePullPolicy: Always
       # digests managed by flash-app pipeline in concourse
-      digest: sha256:e50598bafae5d8e7160b7b5dcf0b1abe6477c3540f4602b5a1e40dd683dec64b
-      git_ref: "97b9ff4"
+      digest: sha256:16c8dabb843329bfcc856d0d9c4c5b00cdc5a1605687fc9564bf29c988197bf9
+      git_ref: "cbc1fb6"
     websocket:
       repository: docker.io/lnflash/galoy-app-websocket
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:d77c5306931cc8d0c01f0a0dc731b4412484b3a0de9996ccf239b5968597f814"
+      digest: "sha256:788abe224251a67be05d391603423b065c3df47b3bdf73f9afc3dde2f0cdde68"
     mongodbMigrate:
       repository: docker.io/lnflash/galoy-app-migrate
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:b173a1c2015fc507095708bd23734ebacfa470498439d5129ddcb92db5e1d328"
+      digest: "sha256:517d3cdec13692eb1a2a3824ac6447d71034bda5393bfbf2cad9fbaeae34a91f"
     mongoBackup:
       repository: us.gcr.io/galoy-org/mongo-backup
       # Currently using Galoy's images. To make changes, see /images & /ci in this repo


### PR DESCRIPTION
# Bump flash image

The flash image will be bumped to digest:
```
sha256:16c8dabb843329bfcc856d0d9c4c5b00cdc5a1605687fc9564bf29c988197bf9
```

The mongodbMigrate image will be bumped to digest:
```
sha256:517d3cdec13692eb1a2a3824ac6447d71034bda5393bfbf2cad9fbaeae34a91f
```

The websocket image will be bumped to digest:
```
sha256:788abe224251a67be05d391603423b065c3df47b3bdf73f9afc3dde2f0cdde68
```

Code diff contained in this image:

https://github.com/lnflash/flash/compare/97b9ff4...cbc1fb6
