### PR TITLE
chore(deps): bump-flash-image-

### DIFF
--- a/charts/flash/Chart.yaml
+++ b/charts/flash/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2 # https://helm.sh/docs/topics/charts/#the-apiversion-field
 name: flash
 description: A Helm chart for the Flash application backend
 type: application
-version: 3.2.17
-appVersion: 0.9.4
+version: 3.2.18
+appVersion: 0.9.5
 dependencies:
   - name: redis
     repository: https://charts.bitnami.com/bitnami

--- a/charts/flash/values.yaml
+++ b/charts/flash/values.yaml
@@ -78,16 +78,16 @@ galoy:
       repository: lnflash/flash-app
       imagePullPolicy: Always
       # digests managed by flash-app pipeline in concourse
-      digest: sha256:e7fa435a392d4de01637f4ba9ceb1b36528ea82b8f78799b6b768a69cd3b43d0
-      git_ref: "a43b321"
+      digest: sha256:f978a2f5b2731ce9d7b4151b37e8092f72853079704302e227740c7ef74f325a
+      git_ref: "3099ebd"
     websocket:
       repository: docker.io/lnflash/galoy-app-websocket
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:0071632c3bdfb7521d856591e6391d30b104bb230fea3b71d7420e20bcb8112b"
+      digest: "sha256:a2fe301023021540f81229c6d4768f2d95d34bfe00f7e665c7df5fb743cba230"
     mongodbMigrate:
       repository: docker.io/lnflash/galoy-app-migrate
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:c6bc19a418e54123fd5369cdb0c210a303079dfbe0f32589d6485f4bb9f018a5"
+      digest: "sha256:8222d038751e46d70ca6cff01889b7d8c85abf653e1266a306c4374ccecd96df"
     mongoBackup:
       repository: us.gcr.io/galoy-org/mongo-backup
       # Currently using Galoy's images. To make changes, see /images & /ci in this repo


### PR DESCRIPTION
# Bump flash image

The flash image will be bumped to digest:
```
sha256:f978a2f5b2731ce9d7b4151b37e8092f72853079704302e227740c7ef74f325a
```

The mongodbMigrate image will be bumped to digest:
```
sha256:8222d038751e46d70ca6cff01889b7d8c85abf653e1266a306c4374ccecd96df
```

The websocket image will be bumped to digest:
```
sha256:a2fe301023021540f81229c6d4768f2d95d34bfe00f7e665c7df5fb743cba230
```

Code diff contained in this image:

https://github.com/lnflash/flash/compare/a43b321...3099ebd
