### PR TITLE
chore(deps): bump-flash-image-

### DIFF
--- a/.github/workflows/dev-smoketest.yaml
+++ b/.github/workflows/dev-smoketest.yaml
@@ -150,7 +150,13 @@ jobs:
       - name: Wait for Flash Workloads
         timeout-minutes: 15
         run: |
-          kubectl -n galoy-dev-galoy wait --for=condition=complete job --all --timeout=10m
+          # Wait only on install-time jobs (migrations). CronJob-spawned jobs
+          # (mongo-backup, price-history cron) fire if the throwaway cluster
+          # lives long enough and can never complete here - waiting on
+          # `job --all` then times out on them (flaked 2026-07-06).
+          for job in $(kubectl -n galoy-dev-galoy get job -o json | jq -r '.items[] | select((.metadata.ownerReferences // []) | map(.kind) | index("CronJob") | not) | .metadata.name'); do
+            kubectl -n galoy-dev-galoy wait --for=condition=complete "job/$job" --timeout=10m
+          done
           for resource in $(kubectl -n galoy-dev-galoy get deployment,statefulset -o name); do
             kubectl -n galoy-dev-galoy rollout status "$resource" --timeout=10m
           done

--- a/.github/workflows/dev-smoketest.yaml
+++ b/.github/workflows/dev-smoketest.yaml
@@ -16,6 +16,17 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
+      - name: Runner disk hygiene
+        run: |
+          # Self-hosted runner accumulates images across runs (each flash
+          # digest ~1-2GB + mirrors); Docker VM disk pressure surfaces as
+          # slow pulls, Pending pods, and helm install timeouts. Log state
+          # and prune anything unused older than a day.
+          docker system df
+          docker system prune -af --filter "until=24h" || true
+          docker volume prune -f || true
+          docker system df
+
       - name: Create k3d Cluster
         run: |
           # Self-heal boot debris: if the runner host was shut down mid-run,

--- a/charts/flash/Chart.yaml
+++ b/charts/flash/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2 # https://helm.sh/docs/topics/charts/#the-apiversion-field
 name: flash
 description: A Helm chart for the Flash application backend
 type: application
-version: 3.2.18
-appVersion: 0.9.5
+version: 3.2.19
+appVersion: 0.9.6
 dependencies:
   - name: redis
     repository: https://charts.bitnami.com/bitnami

--- a/charts/flash/values.yaml
+++ b/charts/flash/values.yaml
@@ -78,16 +78,16 @@ galoy:
       repository: lnflash/flash-app
       imagePullPolicy: Always
       # digests managed by flash-app pipeline in concourse
-      digest: sha256:f978a2f5b2731ce9d7b4151b37e8092f72853079704302e227740c7ef74f325a
-      git_ref: "3099ebd"
+      digest: sha256:d77f838af5877536472ae37d6c44976998328636d2c66c3928b4879a39fbc59a
+      git_ref: "baa96b1"
     websocket:
       repository: docker.io/lnflash/galoy-app-websocket
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:a2fe301023021540f81229c6d4768f2d95d34bfe00f7e665c7df5fb743cba230"
+      digest: "sha256:dfe2752101918c483dfa72d98708b55d74d01d97271d63d2615d79ae8a993061"
     mongodbMigrate:
       repository: docker.io/lnflash/galoy-app-migrate
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:8222d038751e46d70ca6cff01889b7d8c85abf653e1266a306c4374ccecd96df"
+      digest: "sha256:a11348bf44771259a9862461bcff1333ae6a2b88631e05f202807af2d946c1b3"
     mongoBackup:
       repository: us.gcr.io/galoy-org/mongo-backup
       # Currently using Galoy's images. To make changes, see /images & /ci in this repo


### PR DESCRIPTION
# Bump flash image

The flash image will be bumped to digest:
```
sha256:d77f838af5877536472ae37d6c44976998328636d2c66c3928b4879a39fbc59a
```

The mongodbMigrate image will be bumped to digest:
```
sha256:a11348bf44771259a9862461bcff1333ae6a2b88631e05f202807af2d946c1b3
```

The websocket image will be bumped to digest:
```
sha256:dfe2752101918c483dfa72d98708b55d74d01d97271d63d2615d79ae8a993061
```

Code diff contained in this image:

https://github.com/lnflash/flash/compare/3099ebd...baa96b1
