### PR TITLE
feat(flash): bridge-webhook deployment/service/ingress (chart 3.2.20)

### DIFF
--- a/charts/flash/Chart.yaml
+++ b/charts/flash/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2 # https://helm.sh/docs/topics/charts/#the-apiversion-field
 name: flash
 description: A Helm chart for the Flash application backend
 type: application
-version: 3.2.19
+version: 3.2.20
 appVersion: 0.9.6
 dependencies:
   - name: redis

--- a/charts/flash/templates/_helpers.tpl
+++ b/charts/flash/templates/_helpers.tpl
@@ -34,6 +34,10 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- default "ibex-webhook" .Values.galoy.ibex.webhook.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{- define "galoy.bridge.webhook.fullname" -}}
+{{- default "bridge-webhook" .Values.galoy.bridge.webhook.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
 {{/*
 Create a default fully qualified exporter name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).

--- a/charts/flash/templates/bridge-ingress.yaml
+++ b/charts/flash/templates/bridge-ingress.yaml
@@ -1,0 +1,53 @@
+
+{{- if and .Values.galoy.bridge.webhook.enabled .Values.galoy.bridge.webhook.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ template "galoy.bridge.webhook.fullname" . }}
+  labels:
+    app: {{ template "galoy.bridge.webhook.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    cert-manager.io/cluster-issuer: {{ .Values.galoy.bridge.webhook.ingress.clusterIssuer }}
+    nginx.ingress.kubernetes.io/limit-rpm: "10"
+    nginx.ingress.kubernetes.io/limit-burst-multiplier: "20"
+    nginx.ingress.kubernetes.io/limit-connections: "4"
+    # nginx.ingress.kubernetes.io/auth-url: "http://galoy-oathkeeper-api.{{ .Release.Namespace }}.svc.cluster.local:4456/decisions"
+    # nginx.ingress.kubernetes.io/auth-method: GET
+    # nginx.ingress.kubernetes.io/auth-response-headers: Authorization
+    # nginx.ingress.kubernetes.io/auth-snippet: |
+    #   proxy_set_header X-Original-URL $request_uri;
+    #   proxy_set_header X-Forwarded-Method $request_method;
+    #   proxy_set_header X-Forwarded-Proto $scheme;
+    #   proxy_set_header X-Forwarded-Host $host;
+    #   proxy_set_header X-Forwarded-Uri $request_uri;
+    {{- with .Values.galoy.bridge.webhook.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  ingressClassName: nginx
+  tls:
+    {{- range .Values.galoy.bridge.webhook.ingress.hosts }}
+    - hosts:
+      - {{ . }}
+      secretName: {{ printf "%s-tls" . }}
+    {{- end }}
+  rules:
+  {{- range .Values.galoy.bridge.webhook.ingress.hosts }}
+    - host: {{ . }}
+      http: 
+        paths:
+            {{- if $.Values.galoy.bridge.webhook.ingress.extraPaths }}
+            {{- toYaml $.Values.galoy.bridge.webhook.ingress.extraPaths | nindent 10 }}
+            {{- end }}
+          - pathType: ImplementationSpecific
+            path: /
+            backend:
+              service:
+                name: {{ template "galoy.bridge.webhook.fullname" $ }}
+                port:
+                  number: {{ $.Values.galoy.bridge.webhook.port }}
+  {{- end -}}
+{{- end -}}

--- a/charts/flash/templates/bridge-webhook-deployment.yaml
+++ b/charts/flash/templates/bridge-webhook-deployment.yaml
@@ -1,0 +1,161 @@
+{{- if .Values.galoy.bridge.webhook.enabled -}}
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "galoy.bridge.webhook.fullname" . }}
+  labels:
+    app: {{ template "galoy.bridge.webhook.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    app.kubernetes.io/managed-by: Helm
+    kube-monkey/enabled: enabled
+    kube-monkey/identifier: {{ template "galoy.bridge.webhook.fullname" . }}
+    kube-monkey/kill-mode: fixed
+    kube-monkey/kill-value: "1"
+    kube-monkey/mtbf: "8"
+spec:
+  replicas: {{ .Values.galoy.bridge.webhook.replicas }}
+  selector:
+    matchLabels:
+      app: {{ template "galoy.bridge.webhook.fullname" . }}
+  template:
+    metadata:
+      name: {{ template "galoy.bridge.webhook.fullname" . }}
+      labels:
+        app: {{ template "galoy.bridge.webhook.fullname" . }}
+        kube-monkey/enabled: enabled
+        kube-monkey/identifier: {{ template "galoy.bridge.webhook.fullname" . }}
+    spec:
+      serviceAccountName: {{ template "flash.name" . }}
+      initContainers:
+      - name: wait-for-mongodb-migrate
+        image: "groundnuty/k8s-wait-for:v1.5.1"
+        args:
+        - job-wr
+        - {{ template "galoy.migration.jobname" . }}
+      containers:
+      - name: bridge-webhook
+        image: "{{ .Values.galoy.images.app.repository }}@{{ .Values.galoy.images.app.digest }}"
+        args:
+        - "-r"
+        - "/app/lib/services/tracing.js"
+        - "lib/servers/bridge-webhook-server.js"
+        - "-c"
+        - "/var/yaml/custom.yaml"
+        resources:
+          {{ toYaml .Values.galoy.bridge.webhook.resources | nindent 10 }}
+        ports:
+        - name: http
+          containerPort: {{ .Values.galoy.bridge.webhook.port }}
+          protocol: TCP
+        env:
+        - name: HELMREVISION
+          value: {{ .Release.Revision | quote }}
+        - name: LOGLEVEL
+          value: {{ .Values.galoy.bridge.webhook.logLevel | quote }}
+        - name: NETWORK
+          value: {{ .Values.galoy.network }}
+        - name: GALOY_API_PORT
+          value: {{ .Values.galoy.api.port | quote }}
+        - name: GALOY_ADMIN_PORT
+          value: {{ .Values.galoy.admin.port | quote }}
+        - name: WEBSOCKET_PORT
+          value: {{ .Values.galoy.websocket.port | quote }}
+        - name: TRIGGER_PORT
+          value: {{ .Values.galoy.trigger.port | quote }}
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: {{ .Values.tracing.otelExporterOtlpEndpoint | quote }}
+        - name: TRACING_SERVICE_NAME
+          value: "{{ .Values.tracing.prefix }}-{{ template "galoy.bridge.webhook.fullname" . }}"
+        - name: NOSTR_PRIVATE_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.galoy.nostr.zapReceiptsExistingSecret.name }}
+              key: {{ .Values.galoy.nostr.zapReceiptsExistingSecret.key }}
+
+{{/* Databases */}}
+{{ include "galoy.mongodb.env" . | indent 8 }}
+{{ include "galoy.redis.env" . | indent 8 }}
+
+{{/* Bitcoin/LND */}}
+{{ include "galoy.lnd1.env" . | indent 8 }}
+{{ include "galoy.bria.env" . | indent 8 }}
+{{ include "galoy.ibex.env" . | indent 8 }}
+
+{{/* API Specifics */}}
+{{ include "galoy.twilio.env" . | indent 8 }}
+{{ include "galoy.geetest.env" . | indent 8 }}
+
+{{ include "galoy.kratos.env" . | indent 8 }}
+
+        - name: OATHKEEPER_DECISION_ENDPOINT
+          value: http://flash-oathkeeper-api:4456
+
+        - name: PRICE_HISTORY_HOST
+          value: {{ .Values.price.history.host | quote }}
+        - name: PRICE_HISTORY_PORT
+          value: {{ .Values.price.history.port | quote }}
+        - name: PRICE_SERVER_HOST
+          value: {{ .Values.galoy.dealer.host | quote }}
+        - name: PRICE_SERVER_PORT
+          value: {{ .Values.galoy.dealer.port | quote }}
+
+        - name: PRICE_HOST
+          value: {{ .Values.price.realtime.host | quote }}
+
+        - name: SVIX_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.galoy.svixExistingSecret.name }}
+              key: {{ .Values.galoy.svixExistingSecret.secret_key }}
+
+        - name: PROXY_CHECK_APIKEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.galoy.proxyCheckExistingSecret.name }}
+              key: {{ .Values.galoy.proxyCheckExistingSecret.key }}
+
+        - name: LND_PRIORITY
+          value: {{ .Values.galoy.lndPriority }}
+
+        {{ if .Values.galoy.api.firebaseNotifications.enabled }}
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: "/tmp/firebase-service-account/service-account.json"
+        {{ end }}
+
+        livenessProbe:
+          tcpSocket:
+            port: {{ .Values.galoy.bridge.webhook.port }}
+          initialDelaySeconds: {{ .Values.galoy.bridge.webhook.probes.liveness.initialDelaySeconds }}
+          periodSeconds: {{ .Values.galoy.bridge.webhook.probes.liveness.periodSeconds }}
+          failureThreshold: {{ .Values.galoy.bridge.webhook.probes.liveness.failureThreshold }}
+          timeoutSeconds: {{ .Values.galoy.bridge.webhook.probes.liveness.timeoutSeconds }}
+        readinessProbe:
+          tcpSocket:
+            port: {{ .Values.galoy.bridge.webhook.port }}
+          initialDelaySeconds: {{ .Values.galoy.bridge.webhook.probes.readiness.initialDelaySeconds }}
+          failureThreshold: {{ .Values.galoy.bridge.webhook.probes.readiness.failureThreshold }}
+          successThreshold: {{ .Values.galoy.bridge.webhook.probes.readiness.successThreshold }}
+          timeoutSeconds: {{ .Values.galoy.bridge.webhook.probes.readiness.timeoutSeconds }}
+        volumeMounts:
+        {{ if .Values.galoy.api.firebaseNotifications.enabled }}
+        - name: firebase-notifications-service-account
+          mountPath: /tmp/firebase-service-account/
+          readOnly: true
+        {{ end }}
+        - name: custom-yaml
+          mountPath: "/var/yaml/"
+      volumes:
+      {{ if .Values.galoy.api.firebaseNotifications.enabled }}
+      - name: firebase-notifications-service-account
+        secret:
+          secretName: {{ .Values.galoy.api.firebaseNotifications.existingSecret.name }}
+          items:
+          - key: {{ .Values.galoy.api.firebaseNotifications.existingSecret.key }}
+            path: service-account.json
+      {{ end }}
+      - name: custom-yaml
+        secret:
+          secretName: "{{ template "galoy.config.name" . }}"
+{{- end -}}

--- a/charts/flash/templates/bridge-webhook-service.yaml
+++ b/charts/flash/templates/bridge-webhook-service.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.galoy.bridge.webhook.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "galoy.bridge.webhook.fullname" . }}
+  labels:
+    app: {{ template "galoy.bridge.webhook.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: {{ .Values.galoy.bridge.webhook.serviceType }}
+  ports:
+    - port: {{ .Values.galoy.bridge.webhook.port }}
+      targetPort: {{ .Values.galoy.bridge.webhook.port }}
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ template "galoy.bridge.webhook.fullname" . }}
+{{- end -}}

--- a/charts/flash/values.yaml
+++ b/charts/flash/values.yaml
@@ -157,6 +157,33 @@ galoy:
           failureThreshold: 5
           successThreshold: 2
           timeoutSeconds: 1
+  # Bridge webhook receiver (lib/servers/bridge-webhook-server.js). Off by
+  # default: the deployment/service/ingress render only when enabled — flip
+  # per environment alongside the bridge feature flag.
+  bridge:
+    webhook:
+      enabled: false
+      nameOverride:
+      replicas: 1
+      logLevel: debug
+      port: 4009
+      serviceType: ClusterIP
+      resources: {}
+      ingress:
+        enabled:
+        hosts:
+        clusterIssuer:
+      probes:
+        liveness:
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          failureThreshold: 5
+          timeoutSeconds: 1
+        readiness:
+          initialDelaySeconds: 5
+          failureThreshold: 5
+          successThreshold: 2
+          timeoutSeconds: 1
   trigger:
     nameOverride:
     replicas: 1


### PR DESCRIPTION
The bridge webhook server ships in the flash image (`lib/servers/bridge-webhook-server.js`, :4009) but the chart never ran it — Bridge webhooks had no endpoint in any environment (local dev used ngrok straight to the process). Adds the deployment/service/ingress trio mirroring ibex-webhook, gated off by default (`galoy.bridge.webhook.enabled`) so this chart is inert until an environment opts in.

Render-tested: absent when disabled; deployment+service+ingress render with hosts/issuer when enabled. `helm lint` clean.

Companion deployments change (flags-on PR #62 branch) will enable it for TEST with host `bridge.test.flashapp.me`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)