### PR TITLE
chore(deps): bump-flash-image-

### DIFF
--- a/charts/flash/Chart.yaml
+++ b/charts/flash/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2 # https://helm.sh/docs/topics/charts/#the-apiversion-field
 name: flash
 description: A Helm chart for the Flash application backend
 type: application
-version: 3.2.20
-appVersion: 0.9.6
+version: 3.2.21
+appVersion: 0.9.7
 dependencies:
   - name: redis
     repository: https://charts.bitnami.com/bitnami

--- a/charts/flash/values.yaml
+++ b/charts/flash/values.yaml
@@ -78,16 +78,16 @@ galoy:
       repository: lnflash/flash-app
       imagePullPolicy: Always
       # digests managed by flash-app pipeline in concourse
-      digest: sha256:d77f838af5877536472ae37d6c44976998328636d2c66c3928b4879a39fbc59a
-      git_ref: "baa96b1"
+      digest: sha256:8e971d64bd414f01d0331278e24b4a7cb6f6d9e0c7d8f333a73ed61a370ea53b
+      git_ref: "080cd8a"
     websocket:
       repository: docker.io/lnflash/galoy-app-websocket
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:dfe2752101918c483dfa72d98708b55d74d01d97271d63d2615d79ae8a993061"
+      digest: "sha256:5242927507f50a413198c4922e0f710c354c4678b959c8feb8067f949ae593be"
     mongodbMigrate:
       repository: docker.io/lnflash/galoy-app-migrate
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:a11348bf44771259a9862461bcff1333ae6a2b88631e05f202807af2d946c1b3"
+      digest: "sha256:851170191ef3202231f4dc9d9a55bbf04a02f281127b79e606667d7526ed998b"
     mongoBackup:
       repository: us.gcr.io/galoy-org/mongo-backup
       # Currently using Galoy's images. To make changes, see /images & /ci in this repo


### PR DESCRIPTION
# Bump flash image

The flash image will be bumped to digest:
```
sha256:8e971d64bd414f01d0331278e24b4a7cb6f6d9e0c7d8f333a73ed61a370ea53b
```

The mongodbMigrate image will be bumped to digest:
```
sha256:851170191ef3202231f4dc9d9a55bbf04a02f281127b79e606667d7526ed998b
```

The websocket image will be bumped to digest:
```
sha256:5242927507f50a413198c4922e0f710c354c4678b959c8feb8067f949ae593be
```

Code diff contained in this image:

https://github.com/lnflash/flash/compare/baa96b1...080cd8a
