### PR TITLE
strfry: weekly retention + compact maintenance CronJob (chart 1.1.0)

### DIFF
--- a/charts/strfry/Chart.yaml
+++ b/charts/strfry/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.1
+version: 1.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/strfry/templates/deployment.yaml
+++ b/charts/strfry/templates/deployment.yaml
@@ -14,6 +14,25 @@ spec:
       labels:
         app: strfry
     spec:
+      {{- if .Values.maintenance.enabled }}
+      initContainers:
+        # If the weekly maintenance CronJob left a compacted copy of the LMDB,
+        # swap it in before the relay opens the DB. Safe here because strategy
+        # is Recreate: the old pod is gone before this runs.
+        - name: swap-compacted-db
+          image: {{ .Values.maintenance.busyboxImage }}
+          command:
+            - sh
+            - -c
+            - |
+              if [ -f /app/strfry-db/data.mdb.compacted ]; then
+                mv -f /app/strfry-db/data.mdb.compacted /app/strfry-db/data.mdb
+                rm -f /app/strfry-db/lock.mdb
+              fi
+          volumeMounts:
+            - name: strfry-db
+              mountPath: /app/strfry-db
+      {{- end }}
       containers:
         - name: strfry
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}@sha256:{{ .Values.image.digest }}

--- a/charts/strfry/templates/maintenance-cronjob.yml
+++ b/charts/strfry/templates/maintenance-cronjob.yml
@@ -1,0 +1,77 @@
+{{- if .Values.maintenance.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "strfry.fullname" . }}-maintenance
+spec:
+  schedule: {{ .Values.maintenance.schedule | quote }}
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 2
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      template:
+        spec:
+          serviceAccountName: {{ include "strfry.fullname" . }}-maintenance
+          restartPolicy: Never
+          # RWO block-storage volume: must run on the same node as the relay pod
+          affinity:
+            podAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                - labelSelector:
+                    matchLabels:
+                      app: strfry
+                  topologyKey: kubernetes.io/hostname
+          initContainers:
+            # LMDB is multi-process safe on the same node, so delete runs
+            # while the relay is live. Compact writes a compacted copy that
+            # the relay's swap-compacted-db initContainer picks up on the
+            # restart triggered below; deleted pages are only reclaimed on
+            # that swap. Events written between compact and restart are lost
+            # (window is seconds).
+            - name: retention-delete
+              image: {{ .Values.image.repository }}:{{ .Values.image.tag }}@sha256:{{ .Values.image.digest }}
+              workingDir: /app
+              command: ["/app/strfry", "delete", "--age={{ .Values.maintenance.retentionAgeSeconds }}"]
+              volumeMounts:
+                - name: strfry-db
+                  mountPath: /app/strfry-db
+                - name: strfry-conf
+                  mountPath: /etc/strfry.conf
+                  subPath: strfry.conf
+            - name: compact
+              image: {{ .Values.image.repository }}:{{ .Values.image.tag }}@sha256:{{ .Values.image.digest }}
+              workingDir: /app
+              command:
+                - sh
+                - -c
+                - |
+                  set -e
+                  rm -f /app/strfry-db/data.mdb.compacted.tmp
+                  /app/strfry compact /app/strfry-db/data.mdb.compacted.tmp
+                  mv /app/strfry-db/data.mdb.compacted.tmp /app/strfry-db/data.mdb.compacted
+              volumeMounts:
+                - name: strfry-db
+                  mountPath: /app/strfry-db
+                - name: strfry-conf
+                  mountPath: /etc/strfry.conf
+                  subPath: strfry.conf
+          containers:
+            - name: restart-relay
+              image: {{ .Values.maintenance.kubectlImage }}
+              command:
+                - kubectl
+                - -n
+                - {{ .Release.Namespace }}
+                - rollout
+                - restart
+                - deployment/{{ include "strfry.name" . }}
+          volumes:
+            - name: strfry-db
+              persistentVolumeClaim:
+                claimName: {{ include "strfry.fullname" . }}-db-pvc
+            - name: strfry-conf
+              configMap:
+                name: {{ include "strfry.fullname" . }}-configmap
+{{- end }}

--- a/charts/strfry/templates/maintenance-rbac.yml
+++ b/charts/strfry/templates/maintenance-rbac.yml
@@ -1,0 +1,29 @@
+{{- if .Values.maintenance.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "strfry.fullname" . }}-maintenance
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "strfry.fullname" . }}-maintenance
+rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    resourceNames: [{{ include "strfry.name" . | quote }}]
+    verbs: ["get", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "strfry.fullname" . }}-maintenance
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "strfry.fullname" . }}-maintenance
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "strfry.fullname" . }}-maintenance
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/strfry/values.yaml
+++ b/charts/strfry/values.yaml
@@ -10,6 +10,18 @@ persistence:
   enabled: true
   size: 10Gi
 
+# Weekly DB maintenance: delete events older than retentionAgeSeconds
+# (online, LMDB multi-process), compact the LMDB to a sidecar file, then
+# restart the relay so its initContainer swaps the compacted DB in.
+# LMDB never shrinks in place — without this the volume fills up
+# (see lnflash/ops-handbook incidents/2026-07-11-nostr-relay-disk-full.md).
+maintenance:
+  enabled: false
+  schedule: "0 4 * * 0" # Sundays 04:00 UTC
+  retentionAgeSeconds: 7776000 # 90 days
+  kubectlImage: bitnami/kubectl:1.31.4
+  busyboxImage: busybox:1.36.1
+
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
Durable fix for relay.flashapp.me disk-full outage (strfry crashlooped 38 days on a full 10Gi LMDB PVC — see ops-handbook `incidents/2026-07-11-nostr-relay-disk-full.md`).

- Weekly CronJob (opt-in via `maintenance.enabled`): `strfry delete --age=90d` online, then `strfry compact` to a sidecar file, then `kubectl rollout restart` of the relay.
- New relay initContainer swaps the compacted DB in before startup (safe: Recreate strategy).
- RBAC scoped to `get`/`patch` on the strfry deployment only.
- CronJob pod pinned to the relay's node via podAffinity (RWO block storage).

Chart 1.0.1 → 1.1.0. Default off; enabled for prod in the deployments repo (companion PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)