### PR TITLE
fix(price): stop liveness-killing realtime on upstream Ibex feed gaps

### DIFF
--- a/charts/flash/Chart.lock
+++ b/charts/flash/Chart.lock
@@ -16,6 +16,6 @@ dependencies:
   version: 2.13.0
 - name: price
   repository: file://../price
-  version: 0.5.12
-digest: sha256:a56c65f855767c4b3e939a2811679295626ed187350748f98cecea0460a64cd6
-generated: "2026-06-23T11:42:21.176168-07:00"
+  version: 0.6.0
+digest: sha256:bd8d5691191c276a7f0e1ebdfddd10f192f836e5e51b13956a616d5689a09e3c
+generated: "2026-07-11T21:50:17.72861947Z"

--- a/charts/flash/Chart.yaml
+++ b/charts/flash/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2 # https://helm.sh/docs/topics/charts/#the-apiversion-field
 name: flash
 description: A Helm chart for the Flash application backend
 type: application
-version: 3.2.24
+version: 3.2.25
 appVersion: 0.9.11
 dependencies:
   - name: redis
@@ -21,5 +21,5 @@ dependencies:
     repository: oci://ghcr.io/apollographql/helm-charts
     version: 2.13.0
   - name: price
-    version: 0.5.12
+    version: 0.6.0
     repository: "file://../price"

--- a/charts/price/Chart.yaml
+++ b/charts/price/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: price
 description: A helm chart for real-time and historical BTC price data
 type: application
-version: 0.5.12
+version: 0.6.0
 appVersion: 0.2.2
 
 dependencies:

--- a/charts/price/templates/realtime-deployment.yaml
+++ b/charts/price/templates/realtime-deployment.yaml
@@ -70,17 +70,26 @@ spec:
           volumeMounts:
             - name: custom-yaml
               mountPath: "/var/yaml/"
+          # The grpc health endpoint reports NOT_SERVING whenever the realtime
+          # USD price is stale (upstream feed gap), not only when the process
+          # is wedged. Liveness must therefore be far more tolerant than
+          # readiness: restarting cannot conjure an upstream price, and with a
+          # single replica each kill is a full price outage.
           livenessProbe:
             grpc:
               port: 50051
               service: ""
-            initialDelaySeconds: 45
-            timeoutSeconds: 2
+            initialDelaySeconds: {{ .Values.realtime.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.realtime.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.realtime.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.realtime.livenessProbe.failureThreshold }}
           readinessProbe:
             grpc:
               port: 50051
               service: ""
-            timeoutSeconds: 2
+            periodSeconds: {{ .Values.realtime.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.realtime.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.realtime.readinessProbe.failureThreshold }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.realtime.nodeSelector }}

--- a/charts/price/values.yaml
+++ b/charts/price/values.yaml
@@ -30,6 +30,19 @@ nodeSelector: {}
 tolerations: []
 affinity: {}
 realtime:
+  # Liveness tolerates ~2min of NOT_SERVING before restarting: the health
+  # endpoint goes NOT_SERVING on upstream feed staleness (see Ibex
+  # cacheSeconds below), and a restart cannot fix a feed gap. Readiness
+  # stays tight so stale-price pods are pulled from service immediately.
+  livenessProbe:
+    initialDelaySeconds: 45
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 12
+  readinessProbe:
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 3
   config:
     quotes:
       - {code: "USD", symbol: "$", name: "US Dollar", flag: "\U0001F1FA\U0001F1F8"}
@@ -55,7 +68,11 @@ realtime:
         provider: "ibex"
         cron: "*/15 * * * * *"
         config:
-          cacheSeconds: 180
+          # Must be well above the refresh cron: Ibex is the ONLY USD source,
+          # and when the cache expires with no fresh price the health endpoint
+          # reports NOT_SERVING (USD gap -> readiness pulled -> api errors).
+          # 600s tolerates ~40 consecutive failed refreshes before going stale.
+          cacheSeconds: 600
       - name: "free-currency-rates-usd"
         enabled: true
         quoteAlias: "*"
@@ -72,16 +89,18 @@ realtime:
         enabled: true
         quoteAlias: "*"
         base: "BTC"
-        quote: "*"
-        excludedQuotes: ["USD"]
+        # Only quotes kraken actually lists (USD intentionally absent: the
+        # realtime USD rate must track Ibex). Wildcard polling for Caribbean
+        # quotes produced permanent BadSymbol noise (~31k lines/6h).
+        quote: ["EUR", "GBP", "CAD", "CHF", "JPY", "AUD"]
         provider: "ccxt"
         cron: "*/20 * * * * *"
       - name: "bitstamp"
         enabled: true
         quoteAlias: "*"
         base: "BTC"
-        quote: "*"
-        excludedQuotes: ["USD"]
+        # Only quotes bitstamp actually lists (USD intentionally absent).
+        quote: ["EUR", "GBP"]
         provider: "ccxt"
         cron: "*/15 * * * * *"
   image:


### PR DESCRIPTION
## Root cause (diagnosed 2026-07-11, prod + test)

`flash-price-realtime` restarts (14x in prod Jul 9–10, exit 137) are **not crashes**: the grpc health endpoint self-reports `NOT_SERVING` whenever the realtime USD price goes stale, and the liveness probe (3×10s, 2s timeout) kills the pod after any 30s gap. Ibex is the **sole USD source** (kraken/bitstamp/free-currency-rates all exclude USD) and its `cacheSeconds: 180` exactly equals the observed refresh spacing — zero margin, so one missed/slow refresh at the TTL boundary blanks USD. Evidence: 1,652 `NOT_SERVING` liveness failures in prod since Jul 9 (~30/h, ongoing), `PriceNotAvailableError currency=USD` bursts millisecond-correlated with api/trigger `12 UNIMPLEMENTED: USD is not supported` errors, process actively logging at the kill instant, same signature in the test cluster (7 restarts, 3,605 failures). Node OOM/leak/crash ruled out (no limits but MemoryPressure=False, 37% node memory requested, no correlated restarts, no stack traces).

## Fix
1. **Probes parameterized; liveness decoupled from feed staleness** — tolerates ~2 min of NOT_SERVING (12×10s, 5s timeout) before restarting (a restart can't conjure an Ibex price; with 1 replica it only adds downtime — but a truly wedged process still gets restarted). Readiness stays tight (3×10s) so a stale-price pod is pulled from service immediately — that part of the behavior is correct and unchanged.
2. **Ibex `cacheSeconds` 180 → 600** — one missed refresh no longer opens a USD gap; ~40 consecutive failed refreshes needed before NOT_SERVING. Ibex remains the only USD source (intentional — settlement tracks Ibex rates).
3. **kraken/bitstamp poll only quotes they list** — removes ~31k/6h permanent `BadSymbol` log lines that buried real feed errors (schema accepts `quote` as array — verified against `realtime/src/config/schema.ts`).

price `0.5.12 → 0.6.0`, flash `3.2.24 → 3.2.25` (Chart.lock regenerated; template render verified).

## Expected effect
- Pod restarts: ~daily → only on genuine process wedge or ≥12min continuous Ibex outage
- `USD is not supported` api bursts: sharply reduced (only after 10min of continuous Ibex failure instead of one boundary miss)
- Diagnosis doc: ops-handbook `incidents/2026-07-11-price-realtime-liveness-restarts.md`

Deploy: merge → chart publishes → pin flash 3.2.25 in deployments → TEST apply + verify → prod (per test-first policy). Follow-up under consideration after this settles: 2 realtime replicas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)