### PR TITLE
fix(price): pair quoteAlias 1:1 with quote lists — 0.6.0 crashloops realtime

### DIFF
--- a/charts/flash/Chart.lock
+++ b/charts/flash/Chart.lock
@@ -16,6 +16,6 @@ dependencies:
   version: 2.13.0
 - name: price
   repository: file://../price
-  version: 0.6.0
-digest: sha256:bd8d5691191c276a7f0e1ebdfddd10f192f836e5e51b13956a616d5689a09e3c
-generated: "2026-07-11T21:50:17.72861947Z"
+  version: 0.6.1
+digest: sha256:761278ef95c783cc048f80e2bb90ce0f81b8fd1466d3128f09b4dd05400ec049
+generated: "2026-07-12T00:36:11.210792211Z"

--- a/charts/flash/Chart.yaml
+++ b/charts/flash/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2 # https://helm.sh/docs/topics/charts/#the-apiversion-field
 name: flash
 description: A Helm chart for the Flash application backend
 type: application
-version: 3.2.25
+version: 3.2.26
 appVersion: 0.9.11
 dependencies:
   - name: redis
@@ -21,5 +21,5 @@ dependencies:
     repository: oci://ghcr.io/apollographql/helm-charts
     version: 2.13.0
   - name: price
-    version: 0.6.0
+    version: 0.6.1
     repository: "file://../price"

--- a/charts/price/Chart.yaml
+++ b/charts/price/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: price
 description: A helm chart for real-time and historical BTC price data
 type: application
-version: 0.6.0
+version: 0.6.1
 appVersion: 0.2.2
 
 dependencies:

--- a/charts/price/values.yaml
+++ b/charts/price/values.yaml
@@ -87,7 +87,10 @@ realtime:
           cacheSeconds: 1800
       - name: "kraken"
         enabled: true
-        quoteAlias: "*"
+        # quoteAlias must pair 1:1 with quote when quote is a list — the
+        # realtime config loader rejects mismatched lengths (yaml.ts
+        # getExchangesConfig), and "*" coerces to a single-element array.
+        quoteAlias: ["EUR", "GBP", "CAD", "CHF", "JPY", "AUD"]
         base: "BTC"
         # Only quotes kraken actually lists (USD intentionally absent: the
         # realtime USD rate must track Ibex). Wildcard polling for Caribbean
@@ -97,7 +100,7 @@ realtime:
         cron: "*/20 * * * * *"
       - name: "bitstamp"
         enabled: true
-        quoteAlias: "*"
+        quoteAlias: ["EUR", "GBP"]
         base: "BTC"
         # Only quotes bitstamp actually lists (USD intentionally absent).
         quote: ["EUR", "GBP"]


### PR DESCRIPTION
Hotfix for #215: the explicit `quote` lists left `quoteAlias: "*"`, which the realtime config loader rejects at startup — `getExchangesConfig` coerces both to arrays and throws `ConfigError` on length mismatch (`quote.length !== quoteAlias.length`). The JSON schema accepts the array; this second, runtime validation is what 0.6.0 missed.

**Caught by the TEST rehearsal**: both price-realtime ReplicaSets went CrashLoopBackOff (old pods too — they re-read the updated config secret on their next liveness restart), which is also what held the helm upgrade past its deadline (`context deadline exceeded`, release 117 marked failed, TEST still running 3.2.24 pods + crashlooping new RS). **Prod never received 0.6.0.**

Fix: explicit same-length `quoteAlias` arrays for kraken/bitstamp. Verified by rendering the chart and decoding `realtime-config-secret` — all four exchanges now pair (`Ibex USD/*, fcr */*, kraken 6/6, bitstamp 2/2`).

price `0.6.0 → 0.6.1`, flash `3.2.25 → 3.2.26`.

After merge: pin PR → `ENV=test make flash` again (will also clear the failed helm release 117), then the full price verification before prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)