### PR TITLE
chore(deps): bump-flash-image-

### DIFF
--- a/charts/flash/Chart.yaml
+++ b/charts/flash/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2 # https://helm.sh/docs/topics/charts/#the-apiversion-field
 name: flash
 description: A Helm chart for the Flash application backend
 type: application
-version: 3.2.26
-appVersion: 0.9.11
+version: 3.2.27
+appVersion: 0.9.12
 dependencies:
   - name: redis
     repository: https://charts.bitnami.com/bitnami

--- a/charts/flash/values.yaml
+++ b/charts/flash/values.yaml
@@ -78,16 +78,16 @@ galoy:
       repository: lnflash/flash-app
       imagePullPolicy: Always
       # digests managed by flash-app pipeline in concourse
-      digest: sha256:d9ebfe19b416ce5a879ef4b92208228e75646b3dfb81cc9b2cee3c77d64d44d5
-      git_ref: "d719d9e"
+      digest: sha256:27e8df9407b2d84d1b485c7ece94413f8a0d66eeef9910b372d0a9a560d70644
+      git_ref: "63f8acd"
     websocket:
       repository: docker.io/lnflash/galoy-app-websocket
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:8c993ff4e20ca9c44bf5587629eb850d0ae2994df8080cd948978a8acaced3d3"
+      digest: "sha256:4a790ff1576e0fb0d65e13172fe5d2363505b29d3323015100fb4693c3fb13d1"
     mongodbMigrate:
       repository: docker.io/lnflash/galoy-app-migrate
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:1ea0c10d3dd328784e9d181e0316717f031ada25f58a35d2e4423872f7511bc3"
+      digest: "sha256:edd40326d4e3e8b626858581afc7c95bc6da732896ac094122461a10df975f7b"
     mongoBackup:
       repository: us.gcr.io/galoy-org/mongo-backup
       # Currently using Galoy's images. To make changes, see /images & /ci in this repo


### PR DESCRIPTION
# Bump flash image

The flash image will be bumped to digest:
```
sha256:27e8df9407b2d84d1b485c7ece94413f8a0d66eeef9910b372d0a9a560d70644
```

The mongodbMigrate image will be bumped to digest:
```
sha256:edd40326d4e3e8b626858581afc7c95bc6da732896ac094122461a10df975f7b
```

The websocket image will be bumped to digest:
```
sha256:4a790ff1576e0fb0d65e13172fe5d2363505b29d3323015100fb4693c3fb13d1
```

Code diff contained in this image:

https://github.com/lnflash/flash/compare/d719d9e...63f8acd
