### PR TITLE
feat(flash): FIP-07 API-key gateway wiring [ENG-96/102/105]

### DIFF
--- a/charts/flash/templates/api-deployment.yaml
+++ b/charts/flash/templates/api-deployment.yaml
@@ -31,6 +31,10 @@ spec:
         app: {{ template "galoy.api.fullname" . }}
         kube-monkey/enabled: enabled
         kube-monkey/identifier: {{ template "galoy.api.fullname" . }}
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: {{ .Values.galoy.api.metricsPort | default 3001 | quote }}
+        prometheus.io/scrape: "true"
     spec:
       serviceAccountName: {{ template "flash.name" . }}
 
@@ -59,6 +63,9 @@ spec:
         - name: admin
           containerPort: {{ .Values.galoy.admin.port }}
           protocol: TCP
+        - name: metrics
+          containerPort: {{ .Values.galoy.api.metricsPort | default 3001 }}
+          protocol: TCP
 
         env:
         - name: HELMREVISION
@@ -71,6 +78,8 @@ spec:
           value: {{ .Values.galoy.api.port | quote }}
         - name: GALOY_ADMIN_PORT
           value: {{ .Values.galoy.admin.port | quote }}
+        - name: API_METRICS_PORT
+          value: {{ .Values.galoy.api.metricsPort | default 3001 | quote }}
         - name: TRIGGER_PORT
           value: {{ .Values.galoy.trigger.port | quote }}
         - name: WEBSOCKET_PORT

--- a/charts/flash/templates/api-ingress.yaml
+++ b/charts/flash/templates/api-ingress.yaml
@@ -31,6 +31,13 @@ metadata:
       proxy_set_header X-Forwarded-Proto $scheme;
       proxy_set_header X-Forwarded-Host $host;
       proxy_set_header X-Forwarded-Uri $request_uri;
+      # Overwrite any client-supplied X-Real-IP on the oathkeeper auth subrequest
+      # with the ingress-observed peer, so the FIP-07 API-key IP-constraint check
+      # (which oathkeeper forwards to /auth/api-key/check) enforces against a
+      # trusted source IP instead of a spoofable header. nginx sets X-Real-IP on
+      # the main upstream but not on this auth location — without this line the
+      # value is client-controlled.
+      proxy_set_header X-Real-IP $remote_addr;
     {{- with .Values.galoy.api.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/flash/values.yaml
+++ b/charts/flash/values.yaml
@@ -708,6 +708,19 @@ oathkeeper:
                 "extra_from": "@this"
               }
             },
+            {
+              "handler": "bearer_token",
+              "config": {
+                "check_session_url": "http://api:4002/auth/api-key/check",
+                "token_from": { "header": "X-API-KEY" },
+                "forward_http_headers": [ "X-API-KEY" ],
+                "force_method": "GET",
+                "preserve_path": true,
+                "preserve_query": true,
+                "subject_from": "identity.id",
+                "extra_from": "@this"
+              }
+            },
             { "handler": "anonymous" }
           ],
           "authorizer": { "handler": "allow" },
@@ -715,7 +728,7 @@ oathkeeper:
             {
               "handler": "id_token",
               "config": {
-                "claims": '{"sub": "{{ print .Subject }}", "session_id": "{{ print .Extra.id }}", "expires_at": "{{ print .Extra.expires_at }}" }'
+                "claims": '{"sub": "{{ print .Subject }}", "session_id": "{{ print .Extra.id }}", "expires_at": "{{ print .Extra.expires_at }}"{{ if .Extra.scope }}, "scope": "{{ print .Extra.scope }}"{{ end }} }'
               }
             }
           ]

--- a/charts/flash/values.yaml
+++ b/charts/flash/values.yaml
@@ -713,7 +713,7 @@ oathkeeper:
               "config": {
                 "check_session_url": "http://api:4002/auth/api-key/check",
                 "token_from": { "header": "X-API-KEY" },
-                "forward_http_headers": [ "X-API-KEY" ],
+                "forward_http_headers": [ "X-API-KEY", "X-Real-Ip" ],
                 "force_method": "GET",
                 "preserve_path": true,
                 "preserve_query": true,
@@ -728,7 +728,7 @@ oathkeeper:
             {
               "handler": "id_token",
               "config": {
-                "claims": '{"sub": "{{ print .Subject }}", "session_id": "{{ print .Extra.id }}", "expires_at": "{{ print .Extra.expires_at }}"{{ if .Extra.scope }}, "scope": "{{ print .Extra.scope }}"{{ end }} }'
+                "claims": '{"sub": "{{ print .Subject }}", "session_id": "{{ print .Extra.id }}", "expires_at": "{{ print .Extra.expires_at }}"{{ if .Extra.scope }}, "scope": "{{ print .Extra.scope }}"{{ end }}{{ if .Extra.rate_limit }}, "rate_limit": {{ print .Extra.rate_limit }}{{ end }} }'
               }
             }
           ]


### PR DESCRIPTION
Charts-side wiring for the FIP-07 API-key feature. Pairs with **lnflash/flash** `jabariennis/eng-98-106-fip07-api-key-hardening`.

- **`values.yaml`** (`flash-router` oathkeeper `accessRules`): adds a `bearer_token` authenticator on the `/graphql` rule — `token_from: X-API-KEY`, `forward_http_headers: [X-API-KEY, X-Real-Ip]`, `force_method: GET`, pointing at the cluster-internal `http://api:4002/auth/api-key/check`. Falls through to the existing kratos/anonymous authenticators for non-key requests. The `id_token` claims template gains conditional `scope` and numeric `rate_limit` claims — kratos sessions render byte-identical.
- **`api-ingress.yaml`** (ENG-105 security fix): the `auth-snippet` now forces `proxy_set_header X-Real-IP $remote_addr` on the oathkeeper auth subrequest. Without this, ingress-nginx sets `X-Real-IP` only on the main upstream — not the `auth_request` subrequest — so the API-key IP-constraint check ran against a client-controllable header (spoofable, and broken for honest clients). Now it enforces against the ingress-observed peer.
- **`api-deployment.yaml`** (ENG-103): prometheus scrape annotations + metrics containerPort for the new internal API-key metrics listener (`API_METRICS_PORT`, default 3001).

Additive and fail-safe: the added authenticator/claims/headers are no-ops until the paired flash image lands, and rate-limit/IP checks fail safe. Verified end-to-end against the quickstart oathkeeper + Apollo router (lifecycle 11/11, rate limiting, IP trust).

🤖 Generated with [Claude Code](https://claude.com/claude-code)