### PR TITLE
chore(deps): bump-flash-image-

### DIFF
--- a/charts/flash/Chart.yaml
+++ b/charts/flash/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2 # https://helm.sh/docs/topics/charts/#the-apiversion-field
 name: flash
 description: A Helm chart for the Flash application backend
 type: application
-version: 3.2.27
-appVersion: 0.9.12
+version: 3.2.28
+appVersion: 0.9.13
 dependencies:
   - name: redis
     repository: https://charts.bitnami.com/bitnami

--- a/charts/flash/apollo-router/supergraph.graphql
+++ b/charts/flash/apollo-router/supergraph.graphql
@@ -219,6 +219,138 @@ input AddressInput
   title: String!
 }
 
+type ApiKey
+  @join__type(graph: PUBLIC)
+{
+  createdAt: Timestamp!
+  expiresAt: Timestamp
+  id: ID!
+
+  """Public key identifier (the keyId in fk_<keyId>_<secret>)"""
+  keyId: String!
+  lastUsedAt: Timestamp
+  name: String!
+
+  """
+  Per-key request rate limit (requests per minute). Null means the platform default applies.
+  """
+  rateLimitPerMinute: Int
+  scopes: [ApiKeyScope!]!
+
+  """
+  Effective status: keys past their expiry report EXPIRED even before the stored status catches up
+  """
+  status: ApiKeyStatus!
+}
+
+type ApiKeyCreated
+  @join__type(graph: PUBLIC)
+{
+  """The raw API key. Store it securely — it won't be shown again."""
+  apiKey: String!
+  expiresAt: Timestamp
+  id: ID!
+
+  """Public key identifier (the keyId in fk_<keyId>_<secret>)"""
+  keyId: String!
+  name: String!
+
+  """
+  Per-key request rate limit (requests per minute). Null means the platform default applies.
+  """
+  rateLimitPerMinute: Int
+  scopes: [ApiKeyScope!]!
+  warning: String!
+}
+
+input ApiKeyCreateInput
+  @join__type(graph: PUBLIC)
+{
+  """
+  Optional expiration time in seconds. If not set, the key doesn't expire.
+  """
+  expiresIn: Int
+
+  """A descriptive name for the API key (e.g., 'BTCPayServer Integration')"""
+  name: String!
+
+  """
+  Optional per-key request rate limit (requests per minute, 1-10000). If not set, the platform default applies.
+  """
+  rateLimitPerMinute: Int
+
+  """Permission scopes for the key. Defaults to read-only user access."""
+  scopes: [ApiKeyScope!] = [read_user]
+}
+
+type ApiKeyCreatePayload
+  @join__type(graph: PUBLIC)
+{
+  apiKey: ApiKeyCreated
+  errors: [Error!]!
+}
+
+input ApiKeyRevokeInput
+  @join__type(graph: PUBLIC)
+{
+  id: ID!
+}
+
+type ApiKeyRevokePayload
+  @join__type(graph: PUBLIC)
+{
+  apiKey: ApiKey
+  errors: [Error!]!
+}
+
+input ApiKeyRotateInput
+  @join__type(graph: PUBLIC)
+{
+  id: ID!
+}
+
+type ApiKeyRotatePayload
+  @join__type(graph: PUBLIC)
+{
+  apiKey: ApiKeyCreated
+  errors: [Error!]!
+}
+
+"""Permission scopes for API keys (FIP-07)"""
+enum ApiKeyScope
+  @join__type(graph: PUBLIC)
+{
+  """Full administrative access"""
+  admin @join__enumValue(graph: PUBLIC)
+
+  """Read transaction history"""
+  read_transactions @join__enumValue(graph: PUBLIC)
+
+  """Read-only access to user/account data"""
+  read_user @join__enumValue(graph: PUBLIC)
+
+  """Read wallet balances and details"""
+  read_wallet @join__enumValue(graph: PUBLIC)
+
+  """Create transactions"""
+  write_transactions @join__enumValue(graph: PUBLIC)
+
+  """Modify user/account data"""
+  write_user @join__enumValue(graph: PUBLIC)
+
+  """Perform wallet operations (send/receive)"""
+  write_wallet @join__enumValue(graph: PUBLIC)
+}
+
+"""Lifecycle status of an API key (FIP-07)"""
+enum ApiKeyStatus
+  @join__type(graph: PUBLIC)
+{
+  ACTIVE @join__enumValue(graph: PUBLIC)
+  EXPIRED @join__enumValue(graph: PUBLIC)
+  REVOKED @join__enumValue(graph: PUBLIC)
+}
+
 """An Opaque Bearer token"""
 scalar AuthToken
   @join__type(graph: PUBLIC)
@@ -1339,6 +1471,21 @@ type Mutation
   accountEnableNotificationChannel(input: AccountEnableNotificationChannelInput!): AccountUpdateNotificationSettingsPayload!
   accountUpdateDefaultWalletId(input: AccountUpdateDefaultWalletIdInput!): AccountUpdateDefaultWalletIdPayload!
   accountUpdateDisplayCurrency(input: AccountUpdateDisplayCurrencyInput!): AccountUpdateDisplayCurrencyPayload!
+
+  """
+  Generate a new API key for external service authentication. The raw key is only shown once and cannot be retrieved later.
+  """
+  apiKeyCreate(input: ApiKeyCreateInput!): ApiKeyCreatePayload!
+
+  """
+  Revoke an API key. Verification stops honoring it immediately; this cannot be undone.
+  """
+  apiKeyRevoke(input: ApiKeyRevokeInput!): ApiKeyRevokePayload!
+
+  """
+  Rotate an API key: a replacement with a new secret (and keyId) is created with the same name, scopes, and expiry, and the old key is revoked. The new raw key is only shown once.
+  """
+  apiKeyRotate(input: ApiKeyRotateInput!): ApiKeyRotatePayload!
   bridgeAddExternalAccount: BridgeAddExternalAccountPayload!
   bridgeCancelWithdrawalRequest(input: BridgeCancelWithdrawalRequestInput!): BridgeCancelWithdrawalRequestPayload!
   bridgeCreateExternalAccount(input: BridgeCreateExternalAccountInput!): BridgeCreateExternalAccountPayload!
@@ -1810,6 +1957,11 @@ type Query
   @join__type(graph: PUBLIC)
 {
   accountDefaultWallet(username: Username!, walletCurrency: WalletCurrency): PublicWallet!
+
+  """
+  All API keys for the calling account, newest first. Never includes secret material.
+  """
+  apiKeys: [ApiKey!]!
   bridgeExternalAccounts: [BridgeExternalAccount]
   bridgeKycStatus: String
   bridgeVirtualAccount: BridgeVirtualAccount

--- a/charts/flash/values.yaml
+++ b/charts/flash/values.yaml
@@ -78,16 +78,16 @@ galoy:
       repository: lnflash/flash-app
       imagePullPolicy: Always
       # digests managed by flash-app pipeline in concourse
-      digest: sha256:27e8df9407b2d84d1b485c7ece94413f8a0d66eeef9910b372d0a9a560d70644
-      git_ref: "63f8acd"
+      digest: sha256:91fa3a20a51889f7fe746ecf53210127faf5e3b916b8ba34509a618fe365a5d7
+      git_ref: "dd8fc25"
     websocket:
       repository: docker.io/lnflash/galoy-app-websocket
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:4a790ff1576e0fb0d65e13172fe5d2363505b29d3323015100fb4693c3fb13d1"
+      digest: "sha256:147e2657e499703345246e1b49678edbe3b793df51f8523598e5a9bcd930c180"
     mongodbMigrate:
       repository: docker.io/lnflash/galoy-app-migrate
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:edd40326d4e3e8b626858581afc7c95bc6da732896ac094122461a10df975f7b"
+      digest: "sha256:4317b1b0da8c902a475bc6e819801d52a1f72d46ace592ab35cf87cfb73eb272"
     mongoBackup:
       repository: us.gcr.io/galoy-org/mongo-backup
       # Currently using Galoy's images. To make changes, see /images & /ci in this repo


### PR DESCRIPTION
# Bump flash image

The flash image will be bumped to digest:
```
sha256:91fa3a20a51889f7fe746ecf53210127faf5e3b916b8ba34509a618fe365a5d7
```

The mongodbMigrate image will be bumped to digest:
```
sha256:4317b1b0da8c902a475bc6e819801d52a1f72d46ace592ab35cf87cfb73eb272
```

The websocket image will be bumped to digest:
```
sha256:147e2657e499703345246e1b49678edbe3b793df51f8523598e5a9bcd930c180
```

Code diff contained in this image:

https://github.com/lnflash/flash/compare/63f8acd...dd8fc25
