### PR TITLE
ci: self-healing chart publish after bot-merged bumps [unblocks 3.2.28/FIP-07]

### DIFF
--- a/.github/workflows/flashbot-automerge.yaml
+++ b/.github/workflows/flashbot-automerge.yaml
@@ -28,6 +28,10 @@ jobs:
       contents: write
       pull-requests: write
       checks: read
+      # Dispatch publish-flash-chart after merging a chart-version bump (see the
+      # merge step). workflow_dispatch is exempt from the GITHUB_TOKEN
+      # anti-recursion rule, so this token can trigger it without a PAT.
+      actions: write
     steps:
       - name: Merge eligible flashbot PRs
         uses: actions/github-script@v7
@@ -103,14 +107,41 @@ jobs:
               }
 
               core.info(`  All checks passed, merging (squash)...`);
+              let merged = false;
               try {
                 await github.rest.pulls.merge({
                   owner, repo,
                   pull_number: pr.number,
                   merge_method: 'squash'
                 });
+                merged = true;
                 core.info(`  Merged PR #${pr.number}`);
               } catch (e) {
                 core.warning(`  Merge failed for #${pr.number}: ${e.message}`);
+              }
+
+              // A merge performed with GITHUB_TOKEN does NOT trigger
+              // push-based workflows (anti-recursion), so publish-flash-chart
+              // never fires on a bot-merged chart bump and the new version
+              // silently never publishes. workflow_dispatch is exempt from
+              // that rule, so when the merged PR changed the flash chart,
+              // dispatch publish-flash-chart explicitly. Path check mirrors
+              // that workflow's own push trigger (charts/flash/Chart.yaml).
+              if (merged) {
+                try {
+                  const { data: files } = await github.rest.pulls.listFiles({
+                    owner, repo, pull_number: pr.number, per_page: 100
+                  });
+                  if (files.some(f => f.filename === 'charts/flash/Chart.yaml')) {
+                    core.info(`  #${pr.number} bumped the flash chart — dispatching publish-flash-chart`);
+                    await github.rest.actions.createWorkflowDispatch({
+                      owner, repo,
+                      workflow_id: 'publish-flash-chart.yaml',
+                      ref: 'main'
+                    });
+                  }
+                } catch (e) {
+                  core.warning(`  Could not dispatch publish-flash-chart for #${pr.number}: ${e.message}`);
+                }
               }
             }

--- a/.github/workflows/publish-flash-chart.yaml
+++ b/.github/workflows/publish-flash-chart.yaml
@@ -23,6 +23,13 @@ name: Publish flash chart & sync deployments pin
 #                     write to another repo).
 
 on:
+  # Manual trigger: publishes whatever version is currently in
+  # charts/flash/Chart.yaml and opens the deployments pin PR. Needed because the
+  # push trigger below does NOT fire when Chart.yaml is bumped by an Actions
+  # token (flashbot-automerge) — GitHub suppresses push-triggered workflows for
+  # pushes made via the built-in token, so bot-merged image bumps otherwise
+  # never publish. Run this after such a merge.
+  workflow_dispatch:
   push:
     branches: [main]
     paths:


### PR DESCRIPTION
## Problem

The FIP-07 API-key chart (**3.2.28**, bundling the new app image + #218's oathkeeper wiring) is merged to `main` but was **never published to OCI**, so no deployments pin PR opened and it can't be deployed. Verified: OCI has ≤ **3.2.26**; deployments pin is still 3.2.26; `publish-flash-chart` hasn't run since 07-12 00:48.

## Root cause (new as of 2026-07-10)

`flashbot-automerge` merges with the built-in **`GITHUB_TOKEN`**, and — as its own header comment notes — *events created with `GITHUB_TOKEN` don't trigger workflows (anti-recursion)*. Until **#213 (07-10)** the automerge raced and never actually merged, so these bump PRs were merged **by a human** (`islandbitcoin`), whose push fired `publish-flash-chart`. #213 made automerge reliable — so the first two bot-auto-merged bumps (**#217, #219**, both 07-12, by `app/github-actions`) merged fine but their push **didn't** trigger publish. The chart bump silently stalls. This will recur on every bot-merged bump.

## Fix — two parts, fully self-healing, no new secrets

1. **`publish-flash-chart.yaml`** — add a `workflow_dispatch` trigger so the current `Chart.yaml` version can be published on demand.
2. **`flashbot-automerge.yaml`** — after merging a PR that touched `charts/flash/Chart.yaml`, call `createWorkflowDispatch('publish-flash-chart.yaml')`. `workflow_dispatch` is **exempt** from the `GITHUB_TOKEN` anti-recursion rule (the documented escape hatch), so this works with the built-in token — no PAT. Adds `actions: write` to the job.

Job bodies of the publish workflow are otherwise untouched, so every load-bearing invariant is preserved (the `helm dependency update charts/price` step that guards the live price-history StatefulSet, idempotent `already exists` publish, the version-diff pin-PR guard, the concurrency group). Verified against the ops-handbook.

## Ship 3.2.28 to TEST after merging this

Because this PR isn't itself a chart bump, publish won't auto-fire for the already-stalled 3.2.28 — do it once manually:

1. Merge this PR.
2. `gh workflow run publish-flash-chart.yaml --repo lnflash/charts` → publishes 3.2.28 + opens the deployments pin PR (3.2.26 → 3.2.28).
3. Merge that pin PR.
4. `make flash ENV=test` on the jumpbox.

**From here on it's automatic**: every bot-merged chart bump dispatches publish itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)