### PR TITLE
chore(deps): bump-flash-image-

### DIFF
--- a/charts/flash/Chart.yaml
+++ b/charts/flash/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2 # https://helm.sh/docs/topics/charts/#the-apiversion-field
 name: flash
 description: A Helm chart for the Flash application backend
 type: application
-version: 3.2.30
-appVersion: 0.9.15
+version: 3.2.31
+appVersion: 0.9.16
 dependencies:
   - name: redis
     repository: https://charts.bitnami.com/bitnami

--- a/charts/flash/apollo-router/supergraph.graphql
+++ b/charts/flash/apollo-router/supergraph.graphql
@@ -384,6 +384,11 @@ type BankAccount
   """ERPNext bank account identifier"""
   id: ID
   isDefault: Boolean!
+
+  """
+  The account's in-flight update request when it needs the user's attention — Pending (awaiting review) or Rejected (declined). Null once approved/closed, or when none exists.
+  """
+  pendingUpdate: BankAccountUpdateRequest
 }
 
 input BankAccountInput
@@ -394,6 +399,58 @@ input BankAccountInput
   bankBranch: String!
   bankName: String!
   currency: String!
+}
+
+"""
+A pending request to change the details of an approved bank account, awaiting admin review.
+"""
+type BankAccountUpdateRequest
+  @join__type(graph: PUBLIC)
+{
+  """Proposed new account number"""
+  accountNumber: String!
+
+  """Proposed new account type"""
+  accountType: String!
+
+  """Proposed new bank branch"""
+  bankBranch: String!
+
+  """Proposed new bank name"""
+  bankName: String!
+
+  """Account currency (unchanged from the current account)"""
+  currency: String!
+
+  """Reviewer note, set when status is Rejected"""
+  rejectionReason: String
+
+  """Pending | Approved | Rejected | Closed"""
+  status: String!
+}
+
+input BankAccountUpdateRequestInput
+  @join__type(graph: PUBLIC)
+{
+  accountNumber: AccountNumber!
+  accountType: String!
+
+  """ERPNext identifier of the account to update"""
+  bankAccountId: ID!
+  bankBranch: String!
+  bankName: String!
+
+  """Must match the account's current currency (currency is locked)"""
+  currency: String!
+}
+
+type BankAccountUpdateRequestPayload
+  @join__type(graph: PUBLIC)
+{
+  errors: [Error]
+
+  """Status of the created request (Pending on success)"""
+  status: String
 }
 
 type BridgeAddExternalAccountPayload
@@ -1486,6 +1543,7 @@ type Mutation
   Rotate an API key: a replacement with a new secret (and keyId) is created with the same name, scopes, and expiry, and the old key is revoked. The new raw key is only shown once.
   """
   apiKeyRotate(input: ApiKeyRotateInput!): ApiKeyRotatePayload!
+  bankAccountUpdateRequest(input: BankAccountUpdateRequestInput!): BankAccountUpdateRequestPayload!
   bridgeAddExternalAccount: BridgeAddExternalAccountPayload!
   bridgeCancelWithdrawalRequest(input: BridgeCancelWithdrawalRequestInput!): BridgeCancelWithdrawalRequestPayload!
   bridgeCreateExternalAccount(input: BridgeCreateExternalAccountInput!): BridgeCreateExternalAccountPayload!

--- a/charts/flash/values.yaml
+++ b/charts/flash/values.yaml
@@ -78,16 +78,16 @@ galoy:
       repository: lnflash/flash-app
       imagePullPolicy: Always
       # digests managed by flash-app pipeline in concourse
-      digest: sha256:ce3b80e5e912e9eb45d6bc1723cb9855c43d41d5825a3a4ac1b6d22a94861589
-      git_ref: "ae075f8"
+      digest: sha256:f7e9ae2365200892e9dd66910a6e39cb2b20e0346d950ccd16414f369b8b57f4
+      git_ref: "f9f68e1"
     websocket:
       repository: docker.io/lnflash/galoy-app-websocket
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:4b60e3372dc8686c5423fc84d56cfc9e35478b58edc4fbd4f400be5fcd9ead23"
+      digest: "sha256:659de5cf52d885dc403ef31a6fddc2b5cedf2774b78606e935abb8dad6240cee"
     mongodbMigrate:
       repository: docker.io/lnflash/galoy-app-migrate
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:ae82bdde7393097165a73f4237e9339d3c842506b7d1c96664dbee4149ca5c19"
+      digest: "sha256:2a2b885c1524ec09058078655089a935dca28a8dd61432f12cdd4934b5cab1cf"
     mongoBackup:
       repository: us.gcr.io/galoy-org/mongo-backup
       # Currently using Galoy's images. To make changes, see /images & /ci in this repo


### PR DESCRIPTION
# Bump flash image

The flash image will be bumped to digest:
```
sha256:f7e9ae2365200892e9dd66910a6e39cb2b20e0346d950ccd16414f369b8b57f4
```

The mongodbMigrate image will be bumped to digest:
```
sha256:2a2b885c1524ec09058078655089a935dca28a8dd61432f12cdd4934b5cab1cf
```

The websocket image will be bumped to digest:
```
sha256:659de5cf52d885dc403ef31a6fddc2b5cedf2774b78606e935abb8dad6240cee
```

Code diff contained in this image:

https://github.com/lnflash/flash/compare/ae075f8...f9f68e1
