### PR TITLE
fix(strfry): coerce retention --age to int64 so weekly maintenance job runs

### DIFF
--- a/charts/strfry/Chart.yaml
+++ b/charts/strfry/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.0
+version: 1.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/strfry/templates/maintenance-cronjob.yml
+++ b/charts/strfry/templates/maintenance-cronjob.yml
@@ -33,7 +33,10 @@ spec:
             - name: retention-delete
               image: {{ .Values.image.repository }}:{{ .Values.image.tag }}@sha256:{{ .Values.image.digest }}
               workingDir: /app
-              command: ["/app/strfry", "delete", "--age={{ .Values.maintenance.retentionAgeSeconds }}"]
+              # int64 coercion is load-bearing: Helm parses YAML numbers as float64,
+              # so rendering retentionAgeSeconds raw yields "7.776e+06" (scientific
+              # notation), which strfry's --age integer parser rejects. See values.yaml.
+              command: ["/app/strfry", "delete", "--age={{ .Values.maintenance.retentionAgeSeconds | int64 }}"]
               volumeMounts:
                 - name: strfry-db
                   mountPath: /app/strfry-db


### PR DESCRIPTION
## Problem

The `strfry-release-maintenance` CronJob (`0 4 * * 0`, namespace `nostr`) has **never succeeded** in either cluster (`do-tor1-flash-k8s-test` and `-prod`). The `retention-delete` initContainer runs `strfry delete --age=...` and exits 1:

```
strfry error: 7.776e+06 contains non-numeric characters.
```

Because `retention-delete` fails, the downstream `compact` step never runs — so the LMDB is never reclaimed. This is the same failure mode that produced the 2026-07-11 disk-full relay outage.

## Root cause

Helm parses YAML numbers as `float64`, so `maintenance.retentionAgeSeconds: 7776000` (90 days) renders through Go's `%g` formatter as `7.776e+06` (scientific notation). strfry's `--age` parser only accepts a plain integer number of seconds.

## Fix

Pipe the value through `int64` so it renders as a plain integer, and bump the chart `1.1.0 → 1.1.1`.

Verified with `helm template` (full chart renders clean):
```
command: ["/app/strfry", "delete", "--age=7776000"]
```

## Deploy note

strfry is not auto-published (only `charts/flash` is). After merge:
1. `./package-releases.sh strfry` — publish 1.1.1 to `oci://ghcr.io/lnflash`
2. Bump the terraform pin in `lnflash/deployments` (separate PR) and `terraform apply` to test + prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)