### PR TITLE
fix(strfry): quiesce relay so retention delete can run (chart 1.1.2)

### DIFF
--- a/charts/strfry/Chart.yaml
+++ b/charts/strfry/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.1
+version: 1.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/strfry/templates/maintenance-cronjob.yml
+++ b/charts/strfry/templates/maintenance-cronjob.yml
@@ -24,12 +24,24 @@ spec:
                       app: strfry
                   topologyKey: kubernetes.io/hostname
           initContainers:
-            # LMDB is multi-process safe on the same node, so delete runs
-            # while the relay is live. Compact writes a compacted copy that
-            # the relay's swap-compacted-db initContainer picks up on the
-            # restart triggered below; deleted pages are only reclaimed on
-            # that swap. Events written between compact and restart are lost
-            # (window is seconds).
+            # strfry's `delete` needs an exclusive LMDB write transaction, which it
+            # can never obtain while the relay holds the single writer lock — it
+            # fails deterministically with "mdb_txn_begin: Resource temporarily
+            # unavailable", even when the relay is idle. So quiesce the relay first:
+            # scale it to 0 and wait for the pod to terminate and release the DB.
+            # `compact` only needs a read txn, but we keep it inside the quiesced
+            # window for a clean, consistent copy. The relay is scaled back up by
+            # the restart-relay container below; its fresh pod swaps the compacted
+            # copy into place via the Deployment's swap-compacted-db initContainer.
+            - name: scale-down
+              image: {{ .Values.maintenance.kubectlImage }}
+              command:
+                - sh
+                - -c
+                - |
+                  set -e
+                  kubectl -n {{ .Release.Namespace }} scale deployment/{{ include "strfry.name" . }} --replicas=0
+                  kubectl -n {{ .Release.Namespace }} wait --for=delete pod -l app=strfry --timeout=180s
             - name: retention-delete
               image: {{ .Values.image.repository }}:{{ .Values.image.tag }}@sha256:{{ .Values.image.digest }}
               workingDir: /app
@@ -61,15 +73,18 @@ spec:
                   mountPath: /etc/strfry.conf
                   subPath: strfry.conf
           containers:
+            # Scale the relay back up. Recreate strategy + the Deployment's
+            # swap-compacted-db initContainer means the fresh pod swaps in the
+            # compacted DB and clears the stale lock before opening it.
             - name: restart-relay
               image: {{ .Values.maintenance.kubectlImage }}
               command:
                 - kubectl
                 - -n
                 - {{ .Release.Namespace }}
-                - rollout
-                - restart
+                - scale
                 - deployment/{{ include "strfry.name" . }}
+                - --replicas=1
           volumes:
             - name: strfry-db
               persistentVolumeClaim:

--- a/charts/strfry/templates/maintenance-rbac.yml
+++ b/charts/strfry/templates/maintenance-rbac.yml
@@ -9,10 +9,17 @@ kind: Role
 metadata:
   name: {{ include "strfry.fullname" . }}-maintenance
 rules:
+  # scale the relay down/up around the maintenance window (kubectl scale patches
+  # the scale subresource)
   - apiGroups: ["apps"]
-    resources: ["deployments"]
+    resources: ["deployments", "deployments/scale"]
     resourceNames: [{{ include "strfry.name" . | quote }}]
-    verbs: ["get", "patch"]
+    verbs: ["get", "patch", "update"]
+  # `kubectl wait --for=delete pod -l app=strfry` needs to watch pods; list/watch
+  # can't be restricted by resourceName, so this is namespace-scoped
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
Follow-up to #227. With the `--age` int64 fix landed (chart 1.1.1), the maintenance job now gets past arg parsing but hits the next problem:

```
strfry error: mdb_txn_begin: Resource temporarily unavailable
```

## Root cause

strfry's `delete` requires an exclusive LMDB **write** transaction, which it can never obtain while the relay holds LMDB's single writer lock. Verified **deterministic** on the test cluster — it fails even with the relay completely idle (0 writes in 20s). `compact` only needs a read txn and works live; only `delete` is blocked.

strfry 1.0.4 has **no config-based retention policy** (only a `writePolicy.plugin` hook), so `delete` is the only mechanism enforcing retention — we can't drop it. It must run with the relay detached from the DB.

## Fix — quiesce the relay for the maintenance window

- **maintenance-cronjob.yml**: new `scale-down` initContainer scales the relay to 0 and `kubectl wait --for=delete pod -l app=strfry` before `retention-delete` / `compact` run (exclusive access). `restart-relay` now scales back to 1; the fresh pod swaps in the compacted copy via the Deployment's existing `swap-compacted-db` init.
- **maintenance-rbac.yml**: allow the maintenance SA to scale the deployment (`deployments/scale`, `get/patch/update`) and `get/list/watch` pods (for the wait).
- Chart `1.1.1 → 1.1.2`.

## Cost / behavior

A few minutes of relay downtime during the weekly **Sun 04:00** maintenance window (lowest-traffic window; will surface as one Gatus `CONNECTED=false` blip — can be suppressed with a maintenance window later if noisy). Chosen over a zero-downtime delete-on-copy approach because that needs 2–3× the DB size free on the 20Gi PVC, and disk-full was the original failure mode.

## Deploy (strfry is manual-publish)

After merge: `./package-releases.sh strfry` → publishes 1.1.2 to `oci://ghcr.io/lnflash`, then bump the terraform pin in lnflash/deployments and `terraform apply` to test + prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)