### PR TITLE
fix(strfry): replace deleted bitnami/kubectl image (maintenance job ImagePullBackOff)

### DIFF
--- a/charts/strfry/Chart.yaml
+++ b/charts/strfry/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.2
+version: 1.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/strfry/values.yaml
+++ b/charts/strfry/values.yaml
@@ -19,7 +19,11 @@ maintenance:
   enabled: false
   schedule: "0 4 * * 0" # Sundays 04:00 UTC
   retentionAgeSeconds: 7776000 # 90 days
-  kubectlImage: bitnami/kubectl:1.31.4
+  # bitnami/kubectl was removed from Docker Hub (Bitnami deprecated their free
+  # catalog → image NotFound → the maintenance job dies at scale-down with
+  # ImagePullBackOff). rancher/kubectl is a maintained same-version drop-in for
+  # the scale-down + restart-relay steps; verified it pulls (v1.31.4) 2026-07-15.
+  kubectlImage: rancher/kubectl:v1.31.4
   busyboxImage: busybox:1.36.1
 
 imagePullSecrets: []


### PR DESCRIPTION
## Problem

The strfry maintenance CronJob (`strfry-release-maintenance`) can't run — surfaced while verifying 1.1.2 on both envs. Its `scale-down` and `restart-relay` steps pull **`bitnami/kubectl:1.31.4`**, which Bitnami **deleted from Docker Hub** (their free-catalog deprecation):

```
Failed to pull image "bitnami/kubectl:1.31.4": code = NotFound
docker.io/bitnami/kubectl:1.31.4: not found
```

→ `ImagePullBackOff` → the job dies at the first init step on **both test and prod**, and the weekly cronjob is dead too. So retention/compaction still can't run, even though the 1.1.1 age fix and 1.1.2 relay-quiesce fix are live. (The relay is unaffected — scale-down never executes, so strfry stays `1/1`.)

## Fix

Swap `maintenance.kubectlImage` → **`rancher/kubectl:v1.31.4`**, a maintained same-version drop-in (the job only runs `kubectl scale` / `kubectl wait`, which are version-tolerant). Chart `1.1.2 → 1.1.3`.

**Verified it pulls in-cluster** (TEST, throwaway pod):
```
Client Version: v1.31.4
```
And confirmed `bitnami/kubectl:1.31.4` → 404 while `rancher/kubectl:v1.31.4` → 200 on Docker Hub.

## Deploy

Chart 1.1.3 is published to `oci://ghcr.io/lnflash`. Follow with the deployments nostr pin bump (1.1.2 → 1.1.3) → `terraform apply -target=module.nostr` (make flash) test → prod. Re-verify by triggering the maintenance job **on test** (it scales the relay down — test-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)