### PR TITLE
fix(strfry): use alpine/k8s (has a shell) for maintenance kubectl image

### DIFF
--- a/charts/strfry/Chart.yaml
+++ b/charts/strfry/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.3
+version: 1.1.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/strfry/values.yaml
+++ b/charts/strfry/values.yaml
@@ -19,11 +19,15 @@ maintenance:
   enabled: false
   schedule: "0 4 * * 0" # Sundays 04:00 UTC
   retentionAgeSeconds: 7776000 # 90 days
-  # bitnami/kubectl was removed from Docker Hub (Bitnami deprecated their free
-  # catalog → image NotFound → the maintenance job dies at scale-down with
-  # ImagePullBackOff). rancher/kubectl is a maintained same-version drop-in for
-  # the scale-down + restart-relay steps; verified it pulls (v1.31.4) 2026-07-15.
-  kubectlImage: rancher/kubectl:v1.31.4
+  # scale-down/restart-relay use this image. It needs BOTH kubectl AND a shell —
+  # scale-down runs `sh -c "kubectl scale…; kubectl wait…"`. History:
+  #   - bitnami/kubectl:1.31.4 → deleted from Docker Hub (Bitnami free-catalog
+  #     deprecation) → ImagePullBackOff.
+  #   - rancher/kubectl:v1.31.4 → pulls, but is shell-less → scale-down dies with
+  #     exec: "sh": not found.
+  # alpine/k8s bundles kubectl + a busybox shell and is actively maintained.
+  # Verified end-to-end (scale-down→retention→compact→restart) on TEST 2026-07-16.
+  kubectlImage: alpine/k8s:1.31.4
   busyboxImage: busybox:1.36.1
 
 imagePullSecrets: []


### PR DESCRIPTION
## Problem

Chart 1.1.3 (#229) swapped the deleted `bitnami/kubectl:1.31.4` for `rancher/kubectl:v1.31.4`. That fixed the pull — but **`rancher/kubectl` is shell-less** (just the kubectl binary), and the maintenance job's `scale-down` step runs a shell script:

```yaml
command: [sh, -c, "set -e; kubectl scale …; kubectl wait …"]
```

→ the container fails to start: `exec: "sh": executable file not found in $PATH`. Confirmed on TEST — the job dies at scale-down (relay untouched, so no outage, but retention never runs).

## Fix

Use **`alpine/k8s:1.31.4`**, which bundles kubectl **and** a busybox shell, and is actively maintained (not a frozen Bitnami archive). Chart `1.1.3 → 1.1.4`.

## Verified end-to-end on TEST

Ran the full job with this image — first successful maintenance run ever:
```
scale-down       : deployment.apps/strfry scaled  (relay pod terminated)
retention-delete : --age=7776000 → Deleting 13 events → clean exit (no mdb lock error)
compact          : clean
restart-relay    : deployment.apps/strfry scaled → relay back 1/1 Running
```
Also unit-checked the image: `sh -c "kubectl version --client"` → `Client Version: v1.31.4` + `SH_AND_KUBECTL_OK`.

## Deploy

Chart 1.1.4 published to `oci://ghcr.io/lnflash`. Follow with the deployments nostr pin bump (1.1.3 → 1.1.4) → apply test → prod. Re-verify on TEST only (scales the relay down).

🤖 Generated with [Claude Code](https://claude.com/claude-code)