### PR TITLE
chore(deps): bump-flash-image-

### DIFF
--- a/charts/flash/Chart.yaml
+++ b/charts/flash/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2 # https://helm.sh/docs/topics/charts/#the-apiversion-field
 name: flash
 description: A Helm chart for the Flash application backend
 type: application
-version: 3.2.34
-appVersion: 0.9.19
+version: 3.2.35
+appVersion: 0.9.21
 dependencies:
   - name: redis
     repository: https://charts.bitnami.com/bitnami

--- a/charts/flash/apollo-router/supergraph.graphql
+++ b/charts/flash/apollo-router/supergraph.graphql
@@ -515,6 +515,20 @@ type BridgeDeleteExternalAccountPayload
   externalAccount: BridgeExternalAccount
 }
 
+input BridgeExchangePlaidPublicTokenInput
+  @join__type(graph: PUBLIC)
+{
+  linkToken: String!
+  publicToken: String!
+}
+
+type BridgeExchangePlaidPublicTokenPayload
+  @join__type(graph: PUBLIC)
+{
+  errors: [Error!]!
+  message: String
+}
+
 type BridgeExternalAccount
   @join__type(graph: PUBLIC)
 {
@@ -529,7 +543,8 @@ type BridgeExternalAccountLink
   @join__type(graph: PUBLIC)
 {
   expiresAt: String!
-  linkUrl: String!
+  linkToken: String!
+  linkUrl: String @deprecated(reason: "Use linkToken with the Plaid Link SDK. Hosted-URL linking is being retired; this field is best-effort and may be null.")
 }
 
 input BridgeInitiateKycInput
@@ -1549,6 +1564,7 @@ type Mutation
   bridgeCreateExternalAccount(input: BridgeCreateExternalAccountInput!): BridgeCreateExternalAccountPayload!
   bridgeCreateVirtualAccount: BridgeCreateVirtualAccountPayload!
   bridgeDeleteExternalAccount(input: BridgeDeleteExternalAccountInput!): BridgeDeleteExternalAccountPayload!
+  bridgeExchangePlaidPublicToken(input: BridgeExchangePlaidPublicTokenInput!): BridgeExchangePlaidPublicTokenPayload!
   bridgeInitiateKyc(input: BridgeInitiateKycInput!): BridgeInitiateKycPayload!
   bridgeInitiateWithdrawal(input: BridgeInitiateWithdrawalInput!): BridgeInitiateWithdrawalPayload!
   bridgeRequestWithdrawal(input: BridgeRequestWithdrawalInput!): BridgeRequestWithdrawalPayload!

--- a/charts/flash/values.yaml
+++ b/charts/flash/values.yaml
@@ -78,16 +78,16 @@ galoy:
       repository: lnflash/flash-app
       imagePullPolicy: Always
       # digests managed by flash-app pipeline in concourse
-      digest: sha256:b8ec326814f33ca67e897d15b557bdecb043e7d28572d1ff4a0ca6523badd0e9
-      git_ref: "35bd1ad"
+      digest: sha256:147fcfd5868862cd80f02e31a7211aed4c34685987253f1671fbb8e4cba8c331
+      git_ref: "bb0ca8d"
     websocket:
       repository: docker.io/lnflash/galoy-app-websocket
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:27f045e31327f9e42d4b16fedcc23589298339ea787b5230394a1a7c410bd650"
+      digest: "sha256:a1ccb2c0f9f90abc4366969fe3d116fc3a160e8c6ee664b4c31e715f1d73087a"
     mongodbMigrate:
       repository: docker.io/lnflash/galoy-app-migrate
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:658d3691ad12b656ca1d7f9e74f50ff3bc50ec5b6b0c0eb90b198877ba49caaa"
+      digest: "sha256:6f4ec5e988dece30393989678e4ef07a279da1d4d5e8aa982e595c779dda9751"
     mongoBackup:
       repository: us.gcr.io/galoy-org/mongo-backup
       # Currently using Galoy's images. To make changes, see /images & /ci in this repo


### PR DESCRIPTION
# Bump flash image

The flash image will be bumped to digest:
```
sha256:074ece5eaacda98cf2fdaf28f055d46386a10d86895e79ab2ca60325a6c33fc7
```

The mongodbMigrate image will be bumped to digest:
```
sha256:bc8758118e79fb5db06a13f1922e5755f720dd0e1e0964129766ad58216f1415
```

The websocket image will be bumped to digest:
```
sha256:f9a31bfda34fea585179fc2d0ee476eae4b10d140d5290a6436a290fdc6f961d
```

Code diff contained in this image:

https://github.com/lnflash/flash/compare/35bd1ad...5af4416
