### PR TITLE
chore(deps): bump-flash-image-

### DIFF
--- a/charts/flash/Chart.yaml
+++ b/charts/flash/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2 # https://helm.sh/docs/topics/charts/#the-apiversion-field
 name: flash
 description: A Helm chart for the Flash application backend
 type: application
-version: 3.2.34
-appVersion: 0.9.19
+version: 3.2.35
+appVersion: 0.9.22
 dependencies:
   - name: redis
     repository: https://charts.bitnami.com/bitnami

--- a/charts/flash/apollo-router/supergraph.graphql
+++ b/charts/flash/apollo-router/supergraph.graphql
@@ -50,6 +50,50 @@ interface Account
   wallets: [Wallet!]!
 }
 
+type AccountCapabilities
+  @join__type(graph: PUBLIC)
+{
+  """An approved bank account is on file for payouts."""
+  bankPayout: Boolean!
+
+  """Business profile (name and address) on file."""
+  business: Boolean!
+
+  """
+  USD account and routing number available (Bridge KYC approved). Orthogonal to the other capabilities.
+  """
+  usdAccount: Boolean!
+
+  """Phone and identity verified."""
+  verified: Boolean!
+}
+
+enum AccountCapability
+  @join__type(graph: PUBLIC)
+{
+  BANK_PAYOUT @join__enumValue(graph: PUBLIC)
+  BUSINESS @join__enumValue(graph: PUBLIC)
+}
+
+input AccountCapabilityUpgradeRequestInput
+  @join__type(graph: PUBLIC)
+{
+  address: AddressInput!
+  bankAccount: BankAccountInput
+  capability: AccountCapability!
+  fullName: String!
+  idDocument: String
+  terminalsRequested: Int = 0
+}
+
+type AccountCapabilityUpgradeRequestPayload
+  @join__type(graph: PUBLIC)
+{
+  errors: [Error]
+  id: String
+  status: String
+}
+
 type AccountDeletePayload
   @join__type(graph: PUBLIC)
 {
@@ -125,6 +169,14 @@ type AccountLimits
 """Bank account number. Accepts String or Int and coerces to String."""
 scalar AccountNumber
   @join__type(graph: PUBLIC)
+
+enum AccountStatusHeadline
+  @join__type(graph: PUBLIC)
+{
+  BUSINESS @join__enumValue(graph: PUBLIC)
+  TRIAL @join__enumValue(graph: PUBLIC)
+  VERIFIED @join__enumValue(graph: PUBLIC)
+}
 
 input AccountUpdateDefaultWalletIdInput
   @join__type(graph: PUBLIC)
@@ -515,6 +567,20 @@ type BridgeDeleteExternalAccountPayload
   externalAccount: BridgeExternalAccount
 }
 
+input BridgeExchangePlaidPublicTokenInput
+  @join__type(graph: PUBLIC)
+{
+  linkToken: String!
+  publicToken: String!
+}
+
+type BridgeExchangePlaidPublicTokenPayload
+  @join__type(graph: PUBLIC)
+{
+  errors: [Error!]!
+  message: String
+}
+
 type BridgeExternalAccount
   @join__type(graph: PUBLIC)
 {
@@ -529,7 +595,8 @@ type BridgeExternalAccountLink
   @join__type(graph: PUBLIC)
 {
   expiresAt: String!
-  linkUrl: String!
+  linkToken: String!
+  linkUrl: String @deprecated(reason: "Use linkToken with the Plaid Link SDK. Hosted-URL linking is being retired; this field is best-effort and may be null.")
 }
 
 input BridgeInitiateKycInput
@@ -828,6 +895,7 @@ type ConsumerAccount implements Account
   @join__type(graph: PUBLIC)
 {
   callbackEndpoints: [CallbackEndpoint!]!
+  capabilities: AccountCapabilities!
 
   """
   return CSV stream, base64 encoded, of the list of transactions in the wallet
@@ -836,6 +904,10 @@ type ConsumerAccount implements Account
   defaultWalletId: WalletId!
   displayCurrency: DisplayCurrency!
   id: ID!
+
+  """
+  Internal account level, derived from capabilities (ENG-516). Present capabilities and statusHeadline instead of this.
+  """
   level: AccountLevel!
   limits: AccountLimits!
   notificationSettings: NotificationSettings!
@@ -843,6 +915,7 @@ type ConsumerAccount implements Account
   """List the quiz questions of the consumer account"""
   quiz: [Quiz!]!
   realtimePrice: RealtimePrice!
+  statusHeadline: AccountStatusHeadline!
 
   """
   A list of all transactions associated with walletIds optionally passed.
@@ -1521,6 +1594,7 @@ type MobileVersions
 type Mutation
   @join__type(graph: PUBLIC)
 {
+  accountCapabilityUpgradeRequest(input: AccountCapabilityUpgradeRequestInput!): AccountCapabilityUpgradeRequestPayload!
   accountDelete: AccountDeletePayload!
   accountDisableNotificationCategory(input: AccountDisableNotificationCategoryInput!): AccountUpdateNotificationSettingsPayload!
   accountDisableNotificationChannel(input: AccountDisableNotificationChannelInput!): AccountUpdateNotificationSettingsPayload!
@@ -1549,6 +1623,7 @@ type Mutation
   bridgeCreateExternalAccount(input: BridgeCreateExternalAccountInput!): BridgeCreateExternalAccountPayload!
   bridgeCreateVirtualAccount: BridgeCreateVirtualAccountPayload!
   bridgeDeleteExternalAccount(input: BridgeDeleteExternalAccountInput!): BridgeDeleteExternalAccountPayload!
+  bridgeExchangePlaidPublicToken(input: BridgeExchangePlaidPublicTokenInput!): BridgeExchangePlaidPublicTokenPayload!
   bridgeInitiateKyc(input: BridgeInitiateKycInput!): BridgeInitiateKycPayload!
   bridgeInitiateWithdrawal(input: BridgeInitiateWithdrawalInput!): BridgeInitiateWithdrawalPayload!
   bridgeRequestWithdrawal(input: BridgeRequestWithdrawalInput!): BridgeRequestWithdrawalPayload!

--- a/charts/flash/values.yaml
+++ b/charts/flash/values.yaml
@@ -78,16 +78,16 @@ galoy:
       repository: lnflash/flash-app
       imagePullPolicy: Always
       # digests managed by flash-app pipeline in concourse
-      digest: sha256:b8ec326814f33ca67e897d15b557bdecb043e7d28572d1ff4a0ca6523badd0e9
-      git_ref: "35bd1ad"
+      digest: sha256:f4d1cd231ef95f7ca489af65e92f011466e3650007e3b9fa28d71bec99396e60
+      git_ref: "7c7abd1"
     websocket:
       repository: docker.io/lnflash/galoy-app-websocket
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:27f045e31327f9e42d4b16fedcc23589298339ea787b5230394a1a7c410bd650"
+      digest: "sha256:88d1db0fa212bafce4aff54ad7779ee6bf2b5d87f7c5851c2d7a275a9d13afda"
     mongodbMigrate:
       repository: docker.io/lnflash/galoy-app-migrate
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:658d3691ad12b656ca1d7f9e74f50ff3bc50ec5b6b0c0eb90b198877ba49caaa"
+      digest: "sha256:bb78ff2ae450615730ad36777c0a1d694bda384a007adb3aef4d3c18f738a30e"
     mongoBackup:
       repository: us.gcr.io/galoy-org/mongo-backup
       # Currently using Galoy's images. To make changes, see /images & /ci in this repo


### PR DESCRIPTION
# Bump flash image

The flash image will be bumped to digest:
```
sha256:f4d1cd231ef95f7ca489af65e92f011466e3650007e3b9fa28d71bec99396e60
```

The mongodbMigrate image will be bumped to digest:
```
sha256:bb78ff2ae450615730ad36777c0a1d694bda384a007adb3aef4d3c18f738a30e
```

The websocket image will be bumped to digest:
```
sha256:88d1db0fa212bafce4aff54ad7779ee6bf2b5d87f7c5851c2d7a275a9d13afda
```

Code diff contained in this image:

https://github.com/lnflash/flash/compare/35bd1ad...7c7abd1
