### PR TITLE
chore(deps): bump-flash-image-

### DIFF
--- a/charts/flash/Chart.yaml
+++ b/charts/flash/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2 # https://helm.sh/docs/topics/charts/#the-apiversion-field
 name: flash
 description: A Helm chart for the Flash application backend
 type: application
-version: 3.2.35
-appVersion: 0.9.22
+version: 3.2.36
+appVersion: 0.9.23
 dependencies:
   - name: redis
     repository: https://charts.bitnami.com/bitnami

--- a/charts/flash/values.yaml
+++ b/charts/flash/values.yaml
@@ -78,16 +78,16 @@ galoy:
       repository: lnflash/flash-app
       imagePullPolicy: Always
       # digests managed by flash-app pipeline in concourse
-      digest: sha256:f4d1cd231ef95f7ca489af65e92f011466e3650007e3b9fa28d71bec99396e60
-      git_ref: "7c7abd1"
+      digest: sha256:a515f2d4578e6fd20c0e0246cc2298e98a5dc6c976d1b8a865e80bdd0259cfe6
+      git_ref: "79890dd"
     websocket:
       repository: docker.io/lnflash/galoy-app-websocket
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:88d1db0fa212bafce4aff54ad7779ee6bf2b5d87f7c5851c2d7a275a9d13afda"
+      digest: "sha256:0cc9d2c00eb5ea7c46866746a8d17190223a0705a6037164b7d525b0b81fd3ed"
     mongodbMigrate:
       repository: docker.io/lnflash/galoy-app-migrate
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:bb78ff2ae450615730ad36777c0a1d694bda384a007adb3aef4d3c18f738a30e"
+      digest: "sha256:4ed8f7e037cd5c583bd48b002b08b518a37a33ba89af6e91692eabda061094e8"
     mongoBackup:
       repository: us.gcr.io/galoy-org/mongo-backup
       # Currently using Galoy's images. To make changes, see /images & /ci in this repo


### PR DESCRIPTION
# Bump flash image

The flash image will be bumped to digest:
```
sha256:a515f2d4578e6fd20c0e0246cc2298e98a5dc6c976d1b8a865e80bdd0259cfe6
```

The mongodbMigrate image will be bumped to digest:
```
sha256:4ed8f7e037cd5c583bd48b002b08b518a37a33ba89af6e91692eabda061094e8
```

The websocket image will be bumped to digest:
```
sha256:0cc9d2c00eb5ea7c46866746a8d17190223a0705a6037164b7d525b0b81fd3ed
```

Code diff contained in this image:

https://github.com/lnflash/flash/compare/7c7abd1...79890dd
