### PR TITLE
fix(automerge): ignore concurrency-cancelled duplicate check runs

### DIFF
--- a/.github/workflows/flashbot-automerge.yaml
+++ b/.github/workflows/flashbot-automerge.yaml
@@ -78,7 +78,19 @@ jobs:
               // Ignore our own job's check runs: an in-progress automerge run
               // attaches to the same head sha and would otherwise see itself
               // as "still running" and skip forever.
-              const runs = checks.check_runs.filter((r) => r.name !== 'automerge');
+              const allRuns = checks.check_runs.filter((r) => r.name !== 'automerge');
+
+              // A concurrency-cancelled duplicate leaves a permanent
+              // 'cancelled' check run on the head sha next to its successful
+              // sibling, which pins the all-green test false forever and the
+              // bump PR sits unmerged (charts#212, charts#233). Ignore a
+              // cancelled run when another run of the same name succeeded.
+              const succeededNames = new Set(
+                allRuns.filter((r) => r.conclusion === 'success').map((r) => r.name),
+              );
+              const runs = allRuns.filter(
+                (r) => !(r.conclusion === 'cancelled' && succeededNames.has(r.name)),
+              );
               if (runs.length === 0) {
                 core.info(`  No checks yet, skipping`);
                 continue;


### PR DESCRIPTION
## Problem

When a bot PR's CI fires twice (e.g. `dev-smoketest` triggered by two `pull_request` events), the concurrency group cancels one run — and that `cancelled` check run stays on the head SHA forever. The automerge script requires *every* check run to conclude success/neutral/skipped, so the PR never merges and the deploy pipeline silently stalls at the chart step until someone manually reruns the dead job. Hit on charts#212 (2026-07-10) and again on charts#233 (2026-07-17, the flash 3.2.35 bump).

## Fix

Ignore a `cancelled` check run **only when another run of the same name succeeded** on the same SHA. A lone cancelled run with no successful sibling still blocks, as it should.

## Verification

- YAML parses; script logic simulated against the exact #233 check set (cancelled + successful smoketest, successful fmt) → merges; lone-cancelled set → still blocked.
- No test harness exists for workflow-embedded scripts in this repo; behavior will be observable on the next bot bump PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)