### PR TITLE
chore(deps): bump-flash-image-

### DIFF
--- a/charts/flash/Chart.yaml
+++ b/charts/flash/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2 # https://helm.sh/docs/topics/charts/#the-apiversion-field
 name: flash
 description: A Helm chart for the Flash application backend
 type: application
-version: 3.2.38
-appVersion: 0.9.25
+version: 3.2.39
+appVersion: 0.9.26
 dependencies:
   - name: redis
     repository: https://charts.bitnami.com/bitnami

--- a/charts/flash/values.yaml
+++ b/charts/flash/values.yaml
@@ -78,16 +78,16 @@ galoy:
       repository: lnflash/flash-app
       imagePullPolicy: Always
       # digests managed by flash-app pipeline in concourse
-      digest: sha256:98d04d86c72c3c673a3a285eb834e30b4aa9a77b0369f4a4c01d402709b2fb51
-      git_ref: "5bfc686"
+      digest: sha256:0aaa08c6f3ddbf7813d3588802214b325c2dc6cc70741ee7827bc504696461d5
+      git_ref: "38557f2"
     websocket:
       repository: docker.io/lnflash/galoy-app-websocket
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:fe9fff7d18a4082aabecdbe6f51fd96518687c2237b0c283dda99e64d603215e"
+      digest: "sha256:439feee96603c9ebe0983163ed59de3343dd6f5db75246a1ea54e75b5c5e0afe"
     mongodbMigrate:
       repository: docker.io/lnflash/galoy-app-migrate
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:f7e0c3a8c82ee6da78c5883fc5dedf2be52d29e67b4f5d30508c0297f243578e"
+      digest: "sha256:098b63d57b154ad75411e8776437545dc2de16d61b081fa607b920dc11185114"
     mongoBackup:
       repository: us.gcr.io/galoy-org/mongo-backup
       # Currently using Galoy's images. To make changes, see /images & /ci in this repo


### PR DESCRIPTION
# Bump flash image

The flash image will be bumped to digest:
```
sha256:0aaa08c6f3ddbf7813d3588802214b325c2dc6cc70741ee7827bc504696461d5
```

The mongodbMigrate image will be bumped to digest:
```
sha256:098b63d57b154ad75411e8776437545dc2de16d61b081fa607b920dc11185114
```

The websocket image will be bumped to digest:
```
sha256:439feee96603c9ebe0983163ed59de3343dd6f5db75246a1ea54e75b5c5e0afe
```

Code diff contained in this image:

https://github.com/lnflash/flash/compare/5bfc686...38557f2
