### PR TITLE
chore(deps): bump-flash-image-

### DIFF
--- a/charts/flash/Chart.yaml
+++ b/charts/flash/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2 # https://helm.sh/docs/topics/charts/#the-apiversion-field
 name: flash
 description: A Helm chart for the Flash application backend
 type: application
-version: 3.2.39
-appVersion: 0.9.26
+version: 3.2.40
+appVersion: 0.9.27
 dependencies:
   - name: redis
     repository: https://charts.bitnami.com/bitnami

--- a/charts/flash/values.yaml
+++ b/charts/flash/values.yaml
@@ -78,16 +78,16 @@ galoy:
       repository: lnflash/flash-app
       imagePullPolicy: Always
       # digests managed by flash-app pipeline in concourse
-      digest: sha256:0aaa08c6f3ddbf7813d3588802214b325c2dc6cc70741ee7827bc504696461d5
-      git_ref: "38557f2"
+      digest: sha256:9b677c755fa873b33813940095c650982b35a683c459d94775c6958fcf110503
+      git_ref: "0d3b062"
     websocket:
       repository: docker.io/lnflash/galoy-app-websocket
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:439feee96603c9ebe0983163ed59de3343dd6f5db75246a1ea54e75b5c5e0afe"
+      digest: "sha256:20777df1077427cad2ea49afd3adf49bd4e0dde5a92a550b6816b3e65e436b79"
     mongodbMigrate:
       repository: docker.io/lnflash/galoy-app-migrate
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:098b63d57b154ad75411e8776437545dc2de16d61b081fa607b920dc11185114"
+      digest: "sha256:84ea04e01bc7ea0c66642e5a19d1cb8d06e86743af12af9f50a04539962e48b4"
     mongoBackup:
       repository: us.gcr.io/galoy-org/mongo-backup
       # Currently using Galoy's images. To make changes, see /images & /ci in this repo


### PR DESCRIPTION
# Bump flash image

The flash image will be bumped to digest:
```
sha256:9b677c755fa873b33813940095c650982b35a683c459d94775c6958fcf110503
```

The mongodbMigrate image will be bumped to digest:
```
sha256:84ea04e01bc7ea0c66642e5a19d1cb8d06e86743af12af9f50a04539962e48b4
```

The websocket image will be bumped to digest:
```
sha256:20777df1077427cad2ea49afd3adf49bd4e0dde5a92a550b6816b3e65e436b79
```

Code diff contained in this image:

https://github.com/lnflash/flash/compare/38557f2...0d3b062
