### PR TITLE
feat(flash): wire Discord webhook env vars (ops feed + alerts)

### DIFF
--- a/charts/flash/Chart.yaml
+++ b/charts/flash/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2 # https://helm.sh/docs/topics/charts/#the-apiversion-field
 name: flash
 description: A Helm chart for the Flash application backend
 type: application
-version: 3.2.41
+version: 3.2.42
 appVersion: 0.9.28
 dependencies:
   - name: redis

--- a/charts/flash/templates/api-deployment.yaml
+++ b/charts/flash/templates/api-deployment.yaml
@@ -98,6 +98,18 @@ spec:
             secretKeyRef:
               name: {{ .Values.galoy.proxyCheckExistingSecret.name }}
               key: {{ .Values.galoy.proxyCheckExistingSecret.key }}
+        - name: OPS_DISCORD_WEBHOOK_URL
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.galoy.discordWebhooksExistingSecret.name }}
+              key: {{ .Values.galoy.discordWebhooksExistingSecret.ops_key }}
+              optional: true
+        - name: ALERT_DISCORD_WEBHOOK_URL
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.galoy.discordWebhooksExistingSecret.name }}
+              key: {{ .Values.galoy.discordWebhooksExistingSecret.alert_key }}
+              optional: true
 
         - name: LND_PRIORITY
           value: {{ .Values.galoy.lndPriority }}

--- a/charts/flash/templates/bridge-webhook-deployment.yaml
+++ b/charts/flash/templates/bridge-webhook-deployment.yaml
@@ -116,6 +116,19 @@ spec:
               name: {{ .Values.galoy.proxyCheckExistingSecret.name }}
               key: {{ .Values.galoy.proxyCheckExistingSecret.key }}
 
+        - name: OPS_DISCORD_WEBHOOK_URL
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.galoy.discordWebhooksExistingSecret.name }}
+              key: {{ .Values.galoy.discordWebhooksExistingSecret.ops_key }}
+              optional: true
+        - name: ALERT_DISCORD_WEBHOOK_URL
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.galoy.discordWebhooksExistingSecret.name }}
+              key: {{ .Values.galoy.discordWebhooksExistingSecret.alert_key }}
+              optional: true
+
         - name: LND_PRIORITY
           value: {{ .Values.galoy.lndPriority }}
 

--- a/charts/flash/templates/galoy-secrets.yaml
+++ b/charts/flash/templates/galoy-secrets.yaml
@@ -240,5 +240,24 @@ data:
   {{ .Values.galoy.doSpacesExistingSecret.access_key }}: {{ .Values.secrets.doSpacesAccessKey | toString | b64enc }}
   {{ .Values.galoy.doSpacesExistingSecret.secret_key }}: {{ .Values.secrets.doSpacesSecretKey | toString | b64enc }}
 
+---
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.galoy.discordWebhooksExistingSecret.name }}
+  labels:
+    app: {{ template "flash.name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+type: Opaque
+data:
+  {{- if .Values.secrets.opsDiscordWebhookUrl }}
+  {{ .Values.galoy.discordWebhooksExistingSecret.ops_key }}: {{ .Values.secrets.opsDiscordWebhookUrl | toString | b64enc }}
+  {{- end }}
+  {{- if .Values.secrets.alertDiscordWebhookUrl }}
+  {{ .Values.galoy.discordWebhooksExistingSecret.alert_key }}: {{ .Values.secrets.alertDiscordWebhookUrl | toString | b64enc }}
+  {{- end }}
+
 {{- end -}}
 

--- a/charts/flash/templates/ibex-webhook-deployment.yaml
+++ b/charts/flash/templates/ibex-webhook-deployment.yaml
@@ -115,6 +115,19 @@ spec:
               name: {{ .Values.galoy.proxyCheckExistingSecret.name }}
               key: {{ .Values.galoy.proxyCheckExistingSecret.key }}
 
+        - name: OPS_DISCORD_WEBHOOK_URL
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.galoy.discordWebhooksExistingSecret.name }}
+              key: {{ .Values.galoy.discordWebhooksExistingSecret.ops_key }}
+              optional: true
+        - name: ALERT_DISCORD_WEBHOOK_URL
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.galoy.discordWebhooksExistingSecret.name }}
+              key: {{ .Values.galoy.discordWebhooksExistingSecret.alert_key }}
+              optional: true
+
         - name: LND_PRIORITY
           value: {{ .Values.galoy.lndPriority }}
 

--- a/charts/flash/values.yaml
+++ b/charts/flash/values.yaml
@@ -406,6 +406,10 @@ galoy:
   proxyCheckExistingSecret:
     name: proxy-check-api-key
     key: api-key
+  discordWebhooksExistingSecret:
+    name: discord-webhooks
+    ops_key: ops-webhook-url
+    alert_key: alert-webhook-url
   doSpaces:
     endpoint: ""
     region: ""
@@ -544,6 +548,9 @@ secrets:
   svixSecretKey:
   ## Api key for proxy check
   proxyCheckApiKey:
+  ## Discord webhook URLs (ops activity feed + alerts)
+  opsDiscordWebhookUrl:
+  alertDiscordWebhookUrl:
   ## Secrets for DO Spaces
   doSpacesAccessKey:
   doSpacesSecretKey:


### PR DESCRIPTION
## Summary

Wires two secret-backed env vars into the flash chart, chart `3.2.40 → 3.2.41`:

- `OPS_DISCORD_WEBHOOK_URL` — new ops activity feed (lnflash/flash#458)
- `ALERT_DISCORD_WEBHOOK_URL` — existing alerts module, previously not wired in any template

Both are injected into the three workloads that emit events: `api-deployment` (graphql-main-server), `ibex-webhook-deployment`, and `bridge-webhook-deployment`, via `secretKeyRef` → secret `discord-webhooks` (keys `ops-webhook-url` / `alert-webhook-url`), following the `*ExistingSecret` pattern (`galoy.discordWebhooksExistingSecret` in values). `optional: true` so environments without the secret keep working — the backend no-ops when the vars are unset.

`helm lint` clean; rendered output verified to include the vars in all three deployments. (Note: `secrets.create=true` rendering is broken at HEAD from a pre-existing nil `.Values.postgresql.enabled` — unrelated; default `create=false` renders clean.)

## Operator step (out-of-band, per cluster)

```
kubectl -n <flash-ns> create secret generic discord-webhooks \
  --from-literal=ops-webhook-url=<url> \
  --from-literal=alert-webhook-url=<url>
```

TEST first, then prod. Rollout after merge is the usual chart publish → deployments pin bump → `make flash ENV=<env>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UXnQYUbKQe5wUCWEvdAau7