### PR TITLE
chore(deps): bump-flash-image-

### DIFF
--- a/charts/flash/Chart.yaml
+++ b/charts/flash/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2 # https://helm.sh/docs/topics/charts/#the-apiversion-field
 name: flash
 description: A Helm chart for the Flash application backend
 type: application
-version: 3.2.40
-appVersion: 0.9.27
+version: 3.2.41
+appVersion: 0.9.28
 dependencies:
   - name: redis
     repository: https://charts.bitnami.com/bitnami

--- a/charts/flash/values.yaml
+++ b/charts/flash/values.yaml
@@ -78,16 +78,16 @@ galoy:
       repository: lnflash/flash-app
       imagePullPolicy: Always
       # digests managed by flash-app pipeline in concourse
-      digest: sha256:9b677c755fa873b33813940095c650982b35a683c459d94775c6958fcf110503
-      git_ref: "0d3b062"
+      digest: sha256:6fad1c6d357cd54ecf2947b3a8af4bd3a48faca404e392edc65c64b6536efaba
+      git_ref: "00c3e12"
     websocket:
       repository: docker.io/lnflash/galoy-app-websocket
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:20777df1077427cad2ea49afd3adf49bd4e0dde5a92a550b6816b3e65e436b79"
+      digest: "sha256:19a809c1cceccc2e819d1a73495a33c0c44966d56a56ec74fcb136e9c8bf0693"
     mongodbMigrate:
       repository: docker.io/lnflash/galoy-app-migrate
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:84ea04e01bc7ea0c66642e5a19d1cb8d06e86743af12af9f50a04539962e48b4"
+      digest: "sha256:c7b73fcd46c918770326e4be89ca368030e08d3eac94dcda7768a2a3f7d848b9"
     mongoBackup:
       repository: us.gcr.io/galoy-org/mongo-backup
       # Currently using Galoy's images. To make changes, see /images & /ci in this repo


### PR DESCRIPTION
# Bump flash image

The flash image will be bumped to digest:
```
sha256:6fad1c6d357cd54ecf2947b3a8af4bd3a48faca404e392edc65c64b6536efaba
```

The mongodbMigrate image will be bumped to digest:
```
sha256:c7b73fcd46c918770326e4be89ca368030e08d3eac94dcda7768a2a3f7d848b9
```

The websocket image will be bumped to digest:
```
sha256:19a809c1cceccc2e819d1a73495a33c0c44966d56a56ec74fcb136e9c8bf0693
```

Code diff contained in this image:

https://github.com/lnflash/flash/compare/0d3b062...00c3e12
