### PR TITLE
chore(deps): bump-flash-image-

### DIFF
--- a/charts/flash/Chart.yaml
+++ b/charts/flash/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2 # https://helm.sh/docs/topics/charts/#the-apiversion-field
 name: flash
 description: A Helm chart for the Flash application backend
 type: application
-version: 3.2.42
-appVersion: 0.9.28
+version: 3.2.43
+appVersion: 0.9.29
 dependencies:
   - name: redis
     repository: https://charts.bitnami.com/bitnami

--- a/charts/flash/values.yaml
+++ b/charts/flash/values.yaml
@@ -78,16 +78,16 @@ galoy:
       repository: lnflash/flash-app
       imagePullPolicy: Always
       # digests managed by flash-app pipeline in concourse
-      digest: sha256:6fad1c6d357cd54ecf2947b3a8af4bd3a48faca404e392edc65c64b6536efaba
-      git_ref: "00c3e12"
+      digest: sha256:0cc182b10adf9b1d667ecb148bff904f6add584195af2b12344fb7f34597a8af
+      git_ref: "a86dc79"
     websocket:
       repository: docker.io/lnflash/galoy-app-websocket
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:19a809c1cceccc2e819d1a73495a33c0c44966d56a56ec74fcb136e9c8bf0693"
+      digest: "sha256:a4a5d2b2ed6e702a2fa5a3cec87b3e32542c1224ec63620788d181c52e03552d"
     mongodbMigrate:
       repository: docker.io/lnflash/galoy-app-migrate
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:c7b73fcd46c918770326e4be89ca368030e08d3eac94dcda7768a2a3f7d848b9"
+      digest: "sha256:c1bcc0016a48bdf0316961aa420bdc414a53c84427f2773c8f0f25cb7dee8f3d"
     mongoBackup:
       repository: us.gcr.io/galoy-org/mongo-backup
       # Currently using Galoy's images. To make changes, see /images & /ci in this repo


### PR DESCRIPTION
# Bump flash image

The flash image will be bumped to digest:
```
sha256:0cc182b10adf9b1d667ecb148bff904f6add584195af2b12344fb7f34597a8af
```

The mongodbMigrate image will be bumped to digest:
```
sha256:c1bcc0016a48bdf0316961aa420bdc414a53c84427f2773c8f0f25cb7dee8f3d
```

The websocket image will be bumped to digest:
```
sha256:a4a5d2b2ed6e702a2fa5a3cec87b3e32542c1224ec63620788d181c52e03552d
```

Code diff contained in this image:

https://github.com/lnflash/flash/compare/00c3e12...a86dc79
