### PR TITLE
chore(deps): bump-flash-image-

### DIFF
--- a/charts/flash/Chart.yaml
+++ b/charts/flash/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2 # https://helm.sh/docs/topics/charts/#the-apiversion-field
 name: flash
 description: A Helm chart for the Flash application backend
 type: application
-version: 3.2.43
-appVersion: 0.9.29
+version: 3.2.44
+appVersion: 0.9.30
 dependencies:
   - name: redis
     repository: https://charts.bitnami.com/bitnami

--- a/charts/flash/values.yaml
+++ b/charts/flash/values.yaml
@@ -78,16 +78,16 @@ galoy:
       repository: lnflash/flash-app
       imagePullPolicy: Always
       # digests managed by flash-app pipeline in concourse
-      digest: sha256:0cc182b10adf9b1d667ecb148bff904f6add584195af2b12344fb7f34597a8af
-      git_ref: "a86dc79"
+      digest: sha256:4d4ca749c55b4e6b8fcdc6dff405b7f12ce594abd8a07475cb5474eda501187f
+      git_ref: "feecd3a"
     websocket:
       repository: docker.io/lnflash/galoy-app-websocket
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:a4a5d2b2ed6e702a2fa5a3cec87b3e32542c1224ec63620788d181c52e03552d"
+      digest: "sha256:7bab71c6dceb0345705ca81cc907a990c08ef006ca1d6ae7f6b660c964523dd9"
     mongodbMigrate:
       repository: docker.io/lnflash/galoy-app-migrate
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:c1bcc0016a48bdf0316961aa420bdc414a53c84427f2773c8f0f25cb7dee8f3d"
+      digest: "sha256:e643a738b4081f9915ef82db0f408fb2b51dcfe8d381a31d940b039bc9763a5b"
     mongoBackup:
       repository: us.gcr.io/galoy-org/mongo-backup
       # Currently using Galoy's images. To make changes, see /images & /ci in this repo


### PR DESCRIPTION
# Bump flash image

The flash image will be bumped to digest:
```
sha256:4d4ca749c55b4e6b8fcdc6dff405b7f12ce594abd8a07475cb5474eda501187f
```

The mongodbMigrate image will be bumped to digest:
```
sha256:e643a738b4081f9915ef82db0f408fb2b51dcfe8d381a31d940b039bc9763a5b
```

The websocket image will be bumped to digest:
```
sha256:7bab71c6dceb0345705ca81cc907a990c08ef006ca1d6ae7f6b660c964523dd9
```

Code diff contained in this image:

https://github.com/lnflash/flash/compare/a86dc79...feecd3a
