### PR TITLE
chore(deps): bump-flash-image-

### DIFF
--- a/charts/flash/Chart.yaml
+++ b/charts/flash/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2 # https://helm.sh/docs/topics/charts/#the-apiversion-field
 name: flash
 description: A Helm chart for the Flash application backend
 type: application
-version: 3.2.45
-appVersion: 0.9.31
+version: 3.2.46
+appVersion: 0.9.32
 dependencies:
   - name: redis
     repository: https://charts.bitnami.com/bitnami

--- a/charts/flash/values.yaml
+++ b/charts/flash/values.yaml
@@ -78,16 +78,16 @@ galoy:
       repository: lnflash/flash-app
       imagePullPolicy: Always
       # digests managed by flash-app pipeline in concourse
-      digest: sha256:899fc01a8e1fcef5625d3017dc041cb84bffae40e880e32f35236c8d8250152e
-      git_ref: "f744f5e"
+      digest: sha256:43b01ca6bd87a73e151b3ece732ae5903bde479f89a480f5dbda726fa2a85c84
+      git_ref: "8e52708"
     websocket:
       repository: docker.io/lnflash/galoy-app-websocket
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:a160f1a5aa291c1338a4bbf772f48ead1c02a0aceaf4ec2aafdc7b22f434852c"
+      digest: "sha256:46fd64226a6dc837805cd8d41561eeb411622b03dad3bdd257738b3d67ffb5b4"
     mongodbMigrate:
       repository: docker.io/lnflash/galoy-app-migrate
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:a6672e5742029a3ec47ecb76428a135b83ef347a44c19e2751376de03f31629d"
+      digest: "sha256:8243d3aa9e8d50f190b9340803ed426d9a3789f768ae6372c5885aa67fd3a12e"
     mongoBackup:
       repository: us.gcr.io/galoy-org/mongo-backup
       # Currently using Galoy's images. To make changes, see /images & /ci in this repo


### PR DESCRIPTION
# Bump flash image

The flash image will be bumped to digest:
```
sha256:43b01ca6bd87a73e151b3ece732ae5903bde479f89a480f5dbda726fa2a85c84
```

The mongodbMigrate image will be bumped to digest:
```
sha256:8243d3aa9e8d50f190b9340803ed426d9a3789f768ae6372c5885aa67fd3a12e
```

The websocket image will be bumped to digest:
```
sha256:46fd64226a6dc837805cd8d41561eeb411622b03dad3bdd257738b3d67ffb5b4
```

Code diff contained in this image:

https://github.com/lnflash/flash/compare/f744f5e...8e52708
