### PR TITLE
feat(flash): optional WA_BRIDGE env injection for WhatsApp invite delivery (chart 3.2.48)

### DIFF
--- a/charts/flash/Chart.yaml
+++ b/charts/flash/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2 # https://helm.sh/docs/topics/charts/#the-apiversion-field
 name: flash
 description: A Helm chart for the Flash application backend
 type: application
-version: 3.2.47
+version: 3.2.48
 appVersion: 0.9.33
 dependencies:
   - name: redis

--- a/charts/flash/templates/_helpers.tpl
+++ b/charts/flash/templates/_helpers.tpl
@@ -296,6 +296,23 @@ Return Galoy environment variables for Twilio
 {{- end -}}
 
 {{/*
+Return Galoy environment variables for the WhatsApp Baileys wa-bridge.
+The api reads WA_BRIDGE_URL + WA_BRIDGE_SECRET straight from process.env
+(not the yaml config); when both are set, WhatsApp sends route through the
+bridge's authed POST /send instead of Twilio. The include site gates on
+galoy.waBridge.url so an unset url injects nothing (Twilio fallback).
+*/}}
+{{- define "galoy.waBridge.env" -}}
+- name: WA_BRIDGE_URL
+  value: {{ .Values.galoy.waBridge.url | quote }}
+- name: WA_BRIDGE_SECRET
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.galoy.waBridge.existingSecret.name }}
+      key: {{ .Values.galoy.waBridge.existingSecret.send_token_key }}
+{{- end -}}
+
+{{/*
 Return Galoy environment variables for DO Spaces
 */}}
 {{- define "galoy.doSpaces.env" -}}

--- a/charts/flash/templates/api-deployment.yaml
+++ b/charts/flash/templates/api-deployment.yaml
@@ -128,6 +128,9 @@ spec:
 
 {{/* API Specifics */}}
 {{ include "galoy.twilio.env" . | indent 8 }}
+{{- if .Values.galoy.waBridge.url }}
+{{ include "galoy.waBridge.env" . | indent 8 }}
+{{- end }}
 {{ include "galoy.geetest.env" . | indent 8 }}
 
 {{/* DO Spaces */}}

--- a/charts/flash/values.yaml
+++ b/charts/flash/values.yaml
@@ -400,6 +400,16 @@ galoy:
     verify_service_id: TWILIO_VERIFY_SERVICE_ID
     account_sid_key: TWILIO_ACCOUNT_SID
     auth_token_key: TWILIO_AUTH_TOKEN
+  # WhatsApp delivery via the self-hosted Baileys wa-bridge (flash PR #463).
+  # Set url (full endpoint incl. /send) per env to route WhatsApp sends through
+  # the bridge; leave empty (default) to inject nothing and keep the Twilio
+  # fallback. The referenced secret must exist in-cluster wherever url is set
+  # (created by deployments terraform from WA_BRIDGE_SEND_TOKEN).
+  waBridge:
+    url: ""
+    existingSecret:
+      name: wa-bridge-secret
+      send_token_key: send-token
   svixExistingSecret:
     name: svix-secret
     secret_key: svix-secret


### PR DESCRIPTION
## What
Durable wiring for WhatsApp invite delivery (flash PR #463's `process.env.WA_BRIDGE_URL/SECRET` switch), replacing the manual `kubectl set env` that every helm upgrade leaves stale.

- `galoy.waBridge` values block (url + existingSecret ref) mirroring `twilioExistingSecret`
- `galoy.waBridge.env` helper, included in the **api** deployment only, **gated on `galoy.waBridge.url`**
- Chart `3.2.47 → 3.2.48`

## Safety
Default (empty url) renders **byte-identical to 3.2.47** — verified via `helm template` diff (only the chart-version label differs). Prod stays on the Twilio fallback until its values set a url.

With url set, exactly this is injected:
```yaml
- name: WA_BRIDGE_URL
  value: "https://wa-invites.flashapp.me/send"
- name: WA_BRIDGE_SECRET
  valueFrom:
    secretKeyRef: {name: wa-bridge-secret, key: send-token}
```

## Pairs with
deployments PR (next): terraform `wa-bridge-secret` (conditional on `WA_BRIDGE_SEND_TOKEN` tfvar) + `galoy.waBridge.url` in `flash-values.test.yaml`. **Deploy note:** where url is set, the secret must exist or the api pod fails env resolution — TEST-only for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)