### PR TITLE
chore(flash-pay): bump image to 0.6.1 (chart 0.0.9) — LUD-06 msat fix

### DIFF
--- a/charts/flash-pay/Chart.yaml
+++ b/charts/flash-pay/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.8
+version: 0.0.9
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/flash-pay/values.yaml
+++ b/charts/flash-pay/values.yaml
@@ -1,7 +1,7 @@
 image:
   repository: lnflash/flash-pay
-  digest: "sha256:a910ae53ce13159f0c4f52b7aae35445a50fba94e3b702b279cfa58eb4e41486"
-  git_ref: "cf1ff28" # Not used by helm
+  digest: "sha256:62a48b941940f37de36249f09deae3cfc67f8334a05e97219da3505fca02ef7f"
+  git_ref: "ec69592" # Not used by helm
 ingress:
   enabled: false
 service:


### PR DESCRIPTION
Picks up lnflash/flash-pay#39 (ENG-540): the well-known lnurlp handler advertised min/maxSendable in sats instead of msats, capping every Flash lightning address at ~150k sats (~$97) instead of IBEX's actual 150M sats. Also makes the metadata passthrough byte-faithful.

- image digest: `sha256:62a48b941940f37de36249f09deae3cfc67f8334a05e97219da3505fca02ef7f` (Docker Hub tag 0.6.1, built by Concourse from post-merge main `ec69592`)
- chart version: 0.0.8 → 0.0.9

Note: the `bot-bump-flash-pay-image` branch is stale (points at the year-old 0.6.0 digest) — this bump is manual. After merge, publish with `./package-releases.sh flash-pay` and pin 0.0.9 in deployments (companion PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G7A41jET8aH7u5WXP7EZoS