### PR TITLE
chore(deps): bump-flash-image-

### DIFF
--- a/charts/flash/Chart.yaml
+++ b/charts/flash/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2 # https://helm.sh/docs/topics/charts/#the-apiversion-field
 name: flash
 description: A Helm chart for the Flash application backend
 type: application
-version: 3.2.49
-appVersion: 0.9.34
+version: 3.2.50
+appVersion: 0.9.35
 dependencies:
   - name: redis
     repository: https://charts.bitnami.com/bitnami

--- a/charts/flash/apollo-router/supergraph.graphql
+++ b/charts/flash/apollo-router/supergraph.graphql
@@ -1206,6 +1206,11 @@ input IntraLedgerPaymentSendInput
   """Amount in satoshis."""
   amount: SatAmount!
 
+  """
+  Optional client-supplied key; a repeated send with the same key returns the original result instead of paying again.
+  """
+  idempotencyKey: String
+
   """Optional memo to be attached to the payment."""
   memo: Memo
   recipientWalletId: WalletId!
@@ -1229,6 +1234,11 @@ input IntraLedgerUsdPaymentSendInput
 {
   """Amount in cents."""
   amount: FractionalCentAmount!
+
+  """
+  Optional client-supplied key; a repeated send with the same key returns the original result instead of paying again.
+  """
+  idempotencyKey: String
 
   """Optional memo to be attached to the payment."""
   memo: Memo
@@ -1383,6 +1393,11 @@ type LnInvoicePayload
 input LnInvoicePaymentInput
   @join__type(graph: PUBLIC)
 {
+  """
+  Optional client-supplied key; a repeated send with the same key returns the original result instead of paying again.
+  """
+  idempotencyKey: String
+
   """Optional memo to associate with the lightning invoice."""
   memo: Memo
 
@@ -1466,6 +1481,11 @@ input LnNoAmountInvoicePaymentInput
 {
   """Amount to pay in satoshis."""
   amount: SatAmount!
+
+  """
+  Optional client-supplied key; a repeated send with the same key returns the original result instead of paying again.
+  """
+  idempotencyKey: String
 
   """Optional memo to associate with the lightning invoice."""
   memo: Memo

--- a/charts/flash/values.yaml
+++ b/charts/flash/values.yaml
@@ -78,16 +78,16 @@ galoy:
       repository: lnflash/flash-app
       imagePullPolicy: Always
       # digests managed by flash-app pipeline in concourse
-      digest: sha256:9da0048c976e7cf4b9cc33d3865c3f198858be83eeb79cf0b0ab2bde241d844a
-      git_ref: "ef838cd"
+      digest: sha256:115a551f2f5888fcecbb3f5a216533e4b1ebc869b2d99aac657bd57fd5729930
+      git_ref: "28cd919"
     websocket:
       repository: docker.io/lnflash/galoy-app-websocket
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:c3cf41f0b9bbfb0f8f2626f2bb3fbf5db93c68fa2c09b84d097d47cd13d93aa1"
+      digest: "sha256:2f0d62906a24d85a807dfbf98614c9704a3476aa3d69006047863eb097f1be9f"
     mongodbMigrate:
       repository: docker.io/lnflash/galoy-app-migrate
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:bfb0ccdec15959433e1acc672aaedc1ae9f478b2748879025691f2614270cf03"
+      digest: "sha256:c25043e02222f1e11a145f4a544f87179bf75253a3c296ca2c015ddda392ca07"
     mongoBackup:
       repository: us.gcr.io/galoy-org/mongo-backup
       # Currently using Galoy's images. To make changes, see /images & /ci in this repo


### PR DESCRIPTION
# Bump flash image

The flash image will be bumped to digest:
```
sha256:115a551f2f5888fcecbb3f5a216533e4b1ebc869b2d99aac657bd57fd5729930
```

The mongodbMigrate image will be bumped to digest:
```
sha256:c25043e02222f1e11a145f4a544f87179bf75253a3c296ca2c015ddda392ca07
```

The websocket image will be bumped to digest:
```
sha256:2f0d62906a24d85a807dfbf98614c9704a3476aa3d69006047863eb097f1be9f
```

Code diff contained in this image:

https://github.com/lnflash/flash/compare/ef838cd...28cd919
