### PR TITLE
chore(deps): bump-flash-image-

### DIFF
--- a/charts/flash/Chart.yaml
+++ b/charts/flash/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2 # https://helm.sh/docs/topics/charts/#the-apiversion-field
 name: flash
 description: A Helm chart for the Flash application backend
 type: application
-version: 3.2.50
-appVersion: 0.9.35
+version: 3.2.51
+appVersion: 0.9.36
 dependencies:
   - name: redis
     repository: https://charts.bitnami.com/bitnami

--- a/charts/flash/apollo-router/supergraph.graphql
+++ b/charts/flash/apollo-router/supergraph.graphql
@@ -1849,6 +1849,29 @@ type Mutation
   userUpdateUsername(input: UserUpdateUsernameInput!): UserUpdateUsernamePayload! @deprecated(reason: "Username will be moved to @Handle in Accounts. Also SetUsername naming should be used instead of UpdateUsername to reflect the idempotency of Handles")
 }
 
+type MyReferralInvite
+  @join__type(graph: PUBLIC)
+{
+  contact: String!
+  createdAt: String!
+  id: ID!
+  method: InviteMethod!
+  myRewardCents: Int
+  redeemedAt: String
+  rewardPending: Boolean!
+  status: InviteStatus!
+}
+
+type MyReferrals
+  @join__type(graph: PUBLIC)
+{
+  acceptedCount: Int!
+  invites: [MyReferralInvite!]!
+  pendingRewardCount: Int!
+  totalEarnedCents: Int!
+  totalInvites: Int!
+}
+
 type MyUpdatesPayload
   @join__type(graph: PUBLIC)
 {
@@ -2194,6 +2217,7 @@ type Query
   lnInvoicePaymentStatus(input: LnInvoicePaymentStatusInput!): LnInvoicePaymentStatusPayload!
   me: User
   mobileVersions: [MobileVersions]
+  myReferrals(afterId: ID, first: Int): MyReferrals!
   npubByUsername(username: Username!): npubByUsername
   onChainTxFee(address: OnChainAddress!, amount: SatAmount!, speed: PayoutSpeed = FAST, walletId: WalletId!): OnChainTxFee!
   onChainUsdTxFee(address: OnChainAddress!, amount: FractionalCentAmount!, speed: PayoutSpeed = FAST, walletId: WalletId!): OnChainUsdTxFee!

--- a/charts/flash/values.yaml
+++ b/charts/flash/values.yaml
@@ -78,16 +78,16 @@ galoy:
       repository: lnflash/flash-app
       imagePullPolicy: Always
       # digests managed by flash-app pipeline in concourse
-      digest: sha256:115a551f2f5888fcecbb3f5a216533e4b1ebc869b2d99aac657bd57fd5729930
-      git_ref: "28cd919"
+      digest: sha256:085ac566effd61b6e0af60647286251cb7d2c46224b3a51289f94e5c6cf6bdb0
+      git_ref: "4150d64"
     websocket:
       repository: docker.io/lnflash/galoy-app-websocket
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:2f0d62906a24d85a807dfbf98614c9704a3476aa3d69006047863eb097f1be9f"
+      digest: "sha256:306951435b2c3c9abc6f463f19f586eab977c59adf66fd2a254e0a259f3512b3"
     mongodbMigrate:
       repository: docker.io/lnflash/galoy-app-migrate
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:c25043e02222f1e11a145f4a544f87179bf75253a3c296ca2c015ddda392ca07"
+      digest: "sha256:654c4c295f8078bc29f624c64361d383579b5844bb65b8282c71dd9c4fed0188"
     mongoBackup:
       repository: us.gcr.io/galoy-org/mongo-backup
       # Currently using Galoy's images. To make changes, see /images & /ci in this repo


### PR DESCRIPTION
# Bump flash image

The flash image will be bumped to digest:
```
sha256:085ac566effd61b6e0af60647286251cb7d2c46224b3a51289f94e5c6cf6bdb0
```

The mongodbMigrate image will be bumped to digest:
```
sha256:654c4c295f8078bc29f624c64361d383579b5844bb65b8282c71dd9c4fed0188
```

The websocket image will be bumped to digest:
```
sha256:306951435b2c3c9abc6f463f19f586eab977c59adf66fd2a254e0a259f3512b3
```

Code diff contained in this image:

https://github.com/lnflash/flash/compare/28cd919...4150d64
