### PR TITLE
chore(deps): bump-flash-image-

### DIFF
--- a/charts/flash/Chart.yaml
+++ b/charts/flash/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2 # https://helm.sh/docs/topics/charts/#the-apiversion-field
 name: flash
 description: A Helm chart for the Flash application backend
 type: application
-version: 3.2.52
-appVersion: 0.9.37
+version: 3.2.53
+appVersion: 0.9.38
 dependencies:
   - name: redis
     repository: https://charts.bitnami.com/bitnami

--- a/charts/flash/apollo-router/supergraph.graphql
+++ b/charts/flash/apollo-router/supergraph.graphql
@@ -854,6 +854,20 @@ type CashoutOffer
   walletId: WalletId!
 }
 
+type CashoutRate
+  @join__type(graph: PUBLIC)
+{
+  """
+  JMD cents per 1 USD at which a JMD cashout would settle right now — the same rate a cashout offer locks in.
+  """
+  exchangeRate: JMDCents!
+
+  """
+  Flash cashout service fee in basis points, deducted from the USD amount before conversion.
+  """
+  feeBasisPoints: Int!
+}
+
 type CashWalletCutover
   @join__type(graph: PUBLIC)
 {
@@ -2209,6 +2223,7 @@ type Query
   btcPriceList(range: PriceGraphRange!): [PricePoint]
   businessMapMarkers: [MapMarker!]!
   cashWalletCutover: CashWalletCutover!
+  cashoutRate: CashoutRate!
   currencyList: [Currency!]!
   globals: Globals
   invitePreview(token: String!): InvitePreview

--- a/charts/flash/values.yaml
+++ b/charts/flash/values.yaml
@@ -78,16 +78,16 @@ galoy:
       repository: lnflash/flash-app
       imagePullPolicy: Always
       # digests managed by flash-app pipeline in concourse
-      digest: sha256:f3af02ad24558c6de673cdeaa9ccea3adb9442b36a15565c6fb8a704251f975f
-      git_ref: "75073ef"
+      digest: sha256:c10f6804b60a8958c2c9adc9cf46b4afbfca8a4702cd97c2e82903ab37c22a17
+      git_ref: "b065e32"
     websocket:
       repository: docker.io/lnflash/galoy-app-websocket
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:61255def0f23c3a55073513ee3dae9593525c196c29e60b6537edc5d06f1f47c"
+      digest: "sha256:367a1bbfe0cec57178f239cf54212069b8d9da3c9858ae3cdfc99538d4012ca3"
     mongodbMigrate:
       repository: docker.io/lnflash/galoy-app-migrate
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:9b83643f602150c62a5d022ebf6772075d93071b2a7fcc6107240330cc028f87"
+      digest: "sha256:d92492be11b360d2d3ecbe515ea7bd1c761fa1a1f88b46e7a3d708550e181e4a"
     mongoBackup:
       repository: us.gcr.io/galoy-org/mongo-backup
       # Currently using Galoy's images. To make changes, see /images & /ci in this repo


### PR DESCRIPTION
# Bump flash image

The flash image will be bumped to digest:
```
sha256:c10f6804b60a8958c2c9adc9cf46b4afbfca8a4702cd97c2e82903ab37c22a17
```

The mongodbMigrate image will be bumped to digest:
```
sha256:d92492be11b360d2d3ecbe515ea7bd1c761fa1a1f88b46e7a3d708550e181e4a
```

The websocket image will be bumped to digest:
```
sha256:367a1bbfe0cec57178f239cf54212069b8d9da3c9858ae3cdfc99538d4012ca3
```

Code diff contained in this image:

https://github.com/lnflash/flash/compare/75073ef...b065e32
