### PR TITLE
chore(deps): bump-flash-image-

### DIFF
--- a/charts/flash/Chart.yaml
+++ b/charts/flash/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2 # https://helm.sh/docs/topics/charts/#the-apiversion-field
 name: flash
 description: A Helm chart for the Flash application backend
 type: application
-version: 3.2.54
-appVersion: 0.9.38
+version: 3.2.55
+appVersion: 0.9.39
 dependencies:
   - name: redis
     repository: https://charts.bitnami.com/bitnami

--- a/charts/flash/apollo-router/supergraph.graphql
+++ b/charts/flash/apollo-router/supergraph.graphql
@@ -1083,6 +1083,30 @@ scalar FractionalCentAmount
   @join__type(graph: PUBLIC)
 
 """
+Fee parameters for Fygaro card top-ups, so the client can
+compute the net amount a user will receive. Null when the operator settings
+are unavailable — clients should degrade gracefully (hide the estimate).
+"""
+type FygaroTopupInfo
+  @join__type(graph: PUBLIC)
+{
+  """Flash margin fixed fee, in USD."""
+  flashFeeFixed: Float!
+
+  """Flash margin percentage fee (e.g. 2.0 = 2.0%)."""
+  flashFeePercent: Float!
+
+  """Minimum top-up amount, in USD."""
+  minimumAmount: Float!
+
+  """Payment-processor fixed fee, in USD."""
+  processorFeeFixed: Float!
+
+  """Payment-processor percentage fee (e.g. 2.99 = 2.99%)."""
+  processorFeePercent: Float!
+}
+
+"""
 Provides global settings for the application which might have an impact for the user.
 """
 type Globals
@@ -1101,6 +1125,13 @@ type Globals
   """
   cashoutEnabled: Boolean!
   feesInformation: FeesInformation!
+
+  """
+  Fee parameters for Fygaro card top-ups so the app can
+  preview the net amount a user will receive. Null when operator settings
+  are unavailable — the app should hide the estimate and fall back gracefully.
+  """
+  fygaroTopup: FygaroTopupInfo
 
   """
   The domain name for lightning addresses accepted by this Galoy instance

--- a/charts/flash/values.yaml
+++ b/charts/flash/values.yaml
@@ -78,16 +78,16 @@ galoy:
       repository: lnflash/flash-app
       imagePullPolicy: Always
       # digests managed by flash-app pipeline in concourse
-      digest: sha256:c10f6804b60a8958c2c9adc9cf46b4afbfca8a4702cd97c2e82903ab37c22a17
-      git_ref: "b065e32"
+      digest: sha256:3b128dee8adccd110862daa5d583de614fc1f1756c739f138ec5eab38343c994
+      git_ref: "8c07d3e"
     websocket:
       repository: docker.io/lnflash/galoy-app-websocket
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:367a1bbfe0cec57178f239cf54212069b8d9da3c9858ae3cdfc99538d4012ca3"
+      digest: "sha256:adb24d9be5ef2143e3d3c89b9259aeb18fff74b06172e6e5172878e65542f2c4"
     mongodbMigrate:
       repository: docker.io/lnflash/galoy-app-migrate
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:d92492be11b360d2d3ecbe515ea7bd1c761fa1a1f88b46e7a3d708550e181e4a"
+      digest: "sha256:a40569cf61fbfa1a850a60aa51688009ca9332a38dc2ac39408baab4452fbe56"
     mongoBackup:
       repository: us.gcr.io/galoy-org/mongo-backup
       # Currently using Galoy's images. To make changes, see /images & /ci in this repo


### PR DESCRIPTION
# Bump flash image

The flash image will be bumped to digest:
```
sha256:3b128dee8adccd110862daa5d583de614fc1f1756c739f138ec5eab38343c994
```

The mongodbMigrate image will be bumped to digest:
```
sha256:a40569cf61fbfa1a850a60aa51688009ca9332a38dc2ac39408baab4452fbe56
```

The websocket image will be bumped to digest:
```
sha256:adb24d9be5ef2143e3d3c89b9259aeb18fff74b06172e6e5172878e65542f2c4
```

Code diff contained in this image:

https://github.com/lnflash/flash/compare/b065e32...8c07d3e
