### PR TITLE
fix(price): stop asking Ibex for currencies it has no id for

### DIFF
--- a/charts/flash/Chart.lock
+++ b/charts/flash/Chart.lock
@@ -16,6 +16,6 @@ dependencies:
   version: 2.13.0
 - name: price
   repository: file://../price
-  version: 0.6.1
-digest: sha256:761278ef95c783cc048f80e2bb90ce0f81b8fd1466d3128f09b4dd05400ec049
-generated: "2026-07-12T00:36:11.210792211Z"
+  version: 0.6.2
+digest: sha256:8daaa69f8f115ca9320f324cf6cbc922e469feff5264a19b10c29ad8f5eac8be
+generated: "2026-08-16T17:54:50.526714-07:00"

--- a/charts/flash/Chart.yaml
+++ b/charts/flash/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2 # https://helm.sh/docs/topics/charts/#the-apiversion-field
 name: flash
 description: A Helm chart for the Flash application backend
 type: application
-version: 3.2.63
+version: 3.2.64
 appVersion: 0.9.47
 dependencies:
   - name: redis
@@ -21,5 +21,5 @@ dependencies:
     repository: oci://ghcr.io/apollographql/helm-charts
     version: 2.13.0
   - name: price
-    version: 0.6.1
+    version: 0.6.2
     repository: "file://../price"

--- a/charts/price/Chart.yaml
+++ b/charts/price/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: price
 description: A helm chart for real-time and historical BTC price data
 type: application
-version: 0.6.1
+version: 0.6.2
 appVersion: 0.2.2
 
 dependencies:

--- a/charts/price/values.yaml
+++ b/charts/price/values.yaml
@@ -65,6 +65,14 @@ realtime:
         quoteAlias: "*"
         base: "BTC"
         quote: "USD"
+        # IBEX has no currency id for these, so the `quoteAlias: "*"` fan-out
+        # asks it for pairs it can never price: each one fails locally every
+        # cron tick with `Ibex Id not found for currency <X>`, ~36 errors/min
+        # across the 9 of them, on every cluster. Nothing is lost by excluding
+        # them — free-currency-rates already covers every non-USD quote, which
+        # is where these actually get their rate. Currencies IBEX DOES support
+        # (USD, JMD, EUR, GBP, HTG) are untouched.
+        excludedQuotes: ["XCD", "ANG", "BSD", "BBD", "BZD", "KYD", "CUP", "DOP", "TTD"]
         provider: "ibex"
         cron: "*/15 * * * * *"
         config:


### PR DESCRIPTION
## The noise

The Ibex exchange is configured `quoteAlias: "*"`, which fans it out across all 14 display currencies. IBEX has **no currency id** for nine of them — `XCD, ANG, BSD, BBD, BZD, KYD, CUP, DOP, TTD` — so every cron tick fails locally with `Ibex Id not found for currency <X>` before a request is even made.

That's **~36 errors/min on every cluster, continuously** — 534 in a 15-minute sample on prod, and the same on test. It has never been a functional problem, which is precisely why it's worth removing: it's pure noise in the one log a responder greps during a pricing incident. (It's how the real JMD failure nearly got lost last week.)

## Why nothing is lost

`free-currency-rates-usd` already covers `quote: "*"` (excluding only USD), and that's where these nine actually get their rate today. Ibex was only ever contributing *failures* for them.

The currencies IBEX does support are untouched:

```
Ibex will be asked for: USD, JMD, EUR, GBP, HTG
```

JMD in particular still prices off Ibex — that's deliberate and load-bearing.

## Verification

- `helm template` with the **prod** values renders the Ibex entry carrying the nine exclusions, with the other three exchanges (`free-currency-rates-usd`, `kraken`, `bitstamp`) unchanged.
- The runtime honours it: `realtime/src/config/yaml.ts` filters the `quoteAlias: "*"` expansion on `excludedQuotes`.
- `helm dependency update` + `helm package` run clean locally, the same sequence `publish-flash-chart` uses.

## Versioning

`price` 0.6.1 → **0.6.2** (subchart values changed), `flash` 3.2.63 → **3.2.64** with the dependency pin and `Chart.lock` updated, so `publish-flash-chart` publishes it and opens the deployments pin-sync PR automatically.

## Note for TEST

TEST overrides `price.realtime.config.exchanges` **wholesale** for the ibex-swap A/B, so it does **not** inherit this. The same exclusion goes into `lnflash/deployments` `test/flash-values.test.yaml` in a companion PR — verified by rendering that TEST currently has no `excludedQuotes` on its Ibex entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NEoz7nBtdtsHyuYG5wNPQV
