### PR TITLE
chore(deps): bump-flash-image-

### DIFF
--- a/charts/flash/Chart.yaml
+++ b/charts/flash/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2 # https://helm.sh/docs/topics/charts/#the-apiversion-field
 name: flash
 description: A Helm chart for the Flash application backend
 type: application
-version: 3.2.65
-appVersion: 0.9.48
+version: 3.2.66
+appVersion: 0.9.49
 dependencies:
   - name: redis
     repository: https://charts.bitnami.com/bitnami

--- a/charts/flash/apollo-router/supergraph.graphql
+++ b/charts/flash/apollo-router/supergraph.graphql
@@ -1083,6 +1083,46 @@ scalar FractionalCentAmount
   @join__type(graph: PUBLIC)
 
 """
+A server-authorised card top-up. The amount is signed into the URL, so it is the only amount that can be paid through it.
+"""
+type FygaroCheckout
+  @join__type(graph: PUBLIC)
+{
+  """
+  The authorised amount, echoed back so the client can display what was signed.
+  """
+  amount: CentAmount!
+
+  """
+  After this, the URL is rejected by the payment provider and a new one must be requested.
+  """
+  expiresAt: Timestamp!
+
+  """
+  Open this in the payment webview. The amount and the destination account are signed into it and cannot be edited; it stops working at expiresAt.
+  """
+  url: String!
+}
+
+input FygaroCheckoutCreateInput
+  @join__type(graph: PUBLIC)
+{
+  amount: CentAmount!
+}
+
+type FygaroCheckoutCreatePayload
+  @join__type(graph: PUBLIC)
+{
+  checkout: FygaroCheckout
+  errors: [Error!]!
+
+  """
+  How much more could be authorised right now, after this request. Card top-up links you have open but have not paid are ALREADY SUBTRACTED, so this is what would be accepted this second — not a statement of what the account has spent today. Present on refusal too, so the client can say how much would go through instead of only saying no. Null when the allowance could not be established.
+  """
+  remainingAllowance: CentAmount
+}
+
+"""
 Fee parameters for Fygaro card top-ups, so the client can
 compute the net amount a user will receive. Null when the operator settings
 are unavailable — clients should degrade gracefully (hide the estimate).
@@ -1776,6 +1816,7 @@ type Mutation
   createInvite(input: CreateInviteInput!): CreateInvitePayload!
   deviceNotificationTokenCreate(input: DeviceNotificationTokenCreateInput!): SuccessPayload!
   feedbackSubmit(input: FeedbackSubmitInput!): SuccessPayload!
+  fygaroCheckoutCreate(input: FygaroCheckoutCreateInput!): FygaroCheckoutCreatePayload!
   idDocumentUploadUrlGenerate(input: IdDocumentUploadUrlGenerateInput!): IdDocumentUploadUrlPayload!
 
   """

--- a/charts/flash/values.yaml
+++ b/charts/flash/values.yaml
@@ -78,16 +78,16 @@ galoy:
       repository: lnflash/flash-app
       imagePullPolicy: Always
       # digests managed by flash-app pipeline in concourse
-      digest: sha256:5825154d0b4874e809c3afd64bec594db65a42a17d16e619772c96a86a133543
-      git_ref: "aa90a19"
+      digest: sha256:62b51887214cec9174fcfe156ee57be7155ecafd64024f3168436a4a53250bed
+      git_ref: "a6c59f9"
     websocket:
       repository: docker.io/lnflash/galoy-app-websocket
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:e1abe38d7129f91a227aa1500b7ea7c181da294981ef796c85d9d5766e4ab2b3"
+      digest: "sha256:07e034e9e3df12099aab4dd662f9a26d1a3ccb1518c9a343dcc92a45f385d417"
     mongodbMigrate:
       repository: docker.io/lnflash/galoy-app-migrate
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:e5cf855a6820d67abd6a4e0d0bfdc1afb364beed2e96b61547925ade7b435288"
+      digest: "sha256:f7f3a0c1a5e3d43bd2afb1abd45e8ee2ce0aba2d32adca68c346ff25fc6e0c47"
     mongoBackup:
       repository: us.gcr.io/galoy-org/mongo-backup
       # Currently using Galoy's images. To make changes, see /images & /ci in this repo


### PR DESCRIPTION
# Bump flash image

The flash image will be bumped to digest:
```
sha256:62b51887214cec9174fcfe156ee57be7155ecafd64024f3168436a4a53250bed
```

The mongodbMigrate image will be bumped to digest:
```
sha256:f7f3a0c1a5e3d43bd2afb1abd45e8ee2ce0aba2d32adca68c346ff25fc6e0c47
```

The websocket image will be bumped to digest:
```
sha256:07e034e9e3df12099aab4dd662f9a26d1a3ccb1518c9a343dcc92a45f385d417
```

Code diff contained in this image:

https://github.com/lnflash/flash/compare/aa90a19...a6c59f9
