### PR TITLE
feat(flash): expose a rollout strategy knob on the api deployment

### DIFF
--- a/charts/flash/templates/api-deployment.yaml
+++ b/charts/flash/templates/api-deployment.yaml
@@ -19,6 +19,11 @@ spec:
 
   replicas: {{ .Values.galoy.api.replicas }}
 
+  {{- with .Values.galoy.api.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
   selector:
     matchLabels:
       app: {{ template "galoy.api.fullname" . }}

--- a/charts/flash/values.yaml
+++ b/charts/flash/values.yaml
@@ -112,6 +112,17 @@ galoy:
       existingSecret:
         name: galoyapp-firebase-serviceaccount
         key: galoyapp-firebase-serviceaccount.json
+    # Rollout strategy for the api Deployment, passed through verbatim
+    # (e.g. {type: Recreate} or {type: RollingUpdate, rollingUpdate: {maxSurge: 0, maxUnavailable: 1}}).
+    #
+    # UNSET by default, which keeps the Kubernetes default: RollingUpdate
+    # 25%/25%. On a single-replica deployment that rounds to maxSurge 1 /
+    # maxUnavailable 0 — the new pod MUST be scheduled before the old one is
+    # released. On a cluster with no headroom that cannot complete, and a
+    # config change becomes a 15-minute helm timeout instead of a fast
+    # failure (api-on-test, 2026-08-21). Environments that prefer a few
+    # seconds of downtime over an unschedulable upgrade set Recreate here.
+    strategy: {}
     probes:
       enabled: true
       liveness:


### PR DESCRIPTION
Closes the structural gap behind two of the 2026-08-21 deadlocks.

## The gap

`api-deployment.yaml` has no `strategy` block and the chart exposes no knob, so every environment gets the Kubernetes default: `RollingUpdate 25%/25%`. On a **single-replica** deployment that rounds to `maxSurge 1 / maxUnavailable 0` — the new pod must be scheduled **before** the old one is released. On a cluster with no headroom that cannot complete: a config change to api-on-test became a 15-minute helm timeout (deployments#176/#177), and the dragonfly right-sizing hit the identical wall the same day in the erp chart.

## The knob

```yaml
galoy:
  api:
    strategy:
      type: Recreate     # or any strategy object, passed through verbatim
```

**Unset by default — verified a strict no-op**: rendered the chart both ways; default output carries no strategy block (byte-identical to today), `{type: Recreate}` renders exactly that.

## Intended use

- **test** (1 replica, ~90% committed nodes): opts into `Recreate` via the deployments overlay — a few seconds of downtime beats an unschedulable upgrade.
- **prod** (3 replicas, real headroom): stays on the default. Do not set it there.

Rides the next routine chart version bump; no urgency. The deployments-side overlay change follows once this is in a released chart version.