### PR TITLE
chore(deps): bump-flash-image-

### DIFF
--- a/charts/flash/Chart.yaml
+++ b/charts/flash/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2 # https://helm.sh/docs/topics/charts/#the-apiversion-field
 name: flash
 description: A Helm chart for the Flash application backend
 type: application
-version: 3.2.72
-appVersion: 0.9.55
+version: 3.2.73
+appVersion: 0.9.56
 dependencies:
   - name: redis
     repository: https://charts.bitnami.com/bitnami

--- a/charts/flash/apollo-router/supergraph.graphql
+++ b/charts/flash/apollo-router/supergraph.graphql
@@ -1767,6 +1767,11 @@ input LnNoAmountUsdInvoicePaymentInput
   """Amount to pay in USD cents."""
   amount: FractionalCentAmount!
 
+  """
+  Optional client-supplied key; a repeated send with the same key returns the original result instead of paying again.
+  """
+  idempotencyKey: String
+
   """Optional memo to associate with the lightning invoice."""
   memo: Memo
 
@@ -1808,6 +1813,11 @@ input LnurlPaymentSendInput
 {
   """Amount to spend from the USD/USDT wallet, in USD cents."""
   amount: FractionalCentAmount!
+
+  """
+  Optional client-supplied key; a repeated send with the same key returns the original result instead of paying again.
+  """
+  idempotencyKey: String
 
   """LNURL-pay value to decode and pay."""
   lnurl: Lnurl!

--- a/charts/flash/values.yaml
+++ b/charts/flash/values.yaml
@@ -78,16 +78,16 @@ galoy:
       repository: lnflash/flash-app
       imagePullPolicy: Always
       # digests managed by flash-app pipeline in concourse
-      digest: sha256:bc4a8c555b25d788a859dee67765a5f0de4b8cbb82797bd3befdad2b8010992b
-      git_ref: "892346e"
+      digest: sha256:0e4096c98edb2548a1bc490c3efbe30ec953ad3797420054d58c53226e672425
+      git_ref: "f933c06"
     websocket:
       repository: docker.io/lnflash/galoy-app-websocket
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:49a1b1544e78540f4260b42f7da6ff7c8e78e549327a8cfd99169e4b3cb0c96e"
+      digest: "sha256:110173b178e8c6aed5220754c22efa474750794f402e0099daa80f462f00cb91"
     mongodbMigrate:
       repository: docker.io/lnflash/galoy-app-migrate
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:a805ce1fccc010d0d21869e0de55f9c8925645155731b2edb5c57d8a3714421a"
+      digest: "sha256:e5f3905fbfd8b7adb9e4d266560cfd209cb27881aff4f418b6f44883058f4722"
     mongoBackup:
       repository: us.gcr.io/galoy-org/mongo-backup
       # Currently using Galoy's images. To make changes, see /images & /ci in this repo


### PR DESCRIPTION
# Bump flash image

The flash image will be bumped to digest:
```
sha256:0e4096c98edb2548a1bc490c3efbe30ec953ad3797420054d58c53226e672425
```

The mongodbMigrate image will be bumped to digest:
```
sha256:e5f3905fbfd8b7adb9e4d266560cfd209cb27881aff4f418b6f44883058f4722
```

The websocket image will be bumped to digest:
```
sha256:110173b178e8c6aed5220754c22efa474750794f402e0099daa80f462f00cb91
```

Code diff contained in this image:

https://github.com/lnflash/flash/compare/892346e...f933c06
