### PR TITLE
fix(flash): read migrate-job notification topics from a settable path (ENG-565)

### DIFF
--- a/charts/flash/Chart.yaml
+++ b/charts/flash/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2 # https://helm.sh/docs/topics/charts/#the-apiversion-field
 name: flash
 description: A Helm chart for the Flash application backend
 type: application
-version: 3.2.73
+version: 3.2.74
 appVersion: 0.9.56
 dependencies:
   - name: redis

--- a/charts/flash/templates/galoy-migration-job.yaml
+++ b/charts/flash/templates/galoy-migration-job.yaml
@@ -44,5 +44,16 @@ spec:
         env:
 {{ include "galoy.mongodb.env" . | indent 8 }}
         - name: NOTIFICATION_TOPICS
-          value: {{ join "," .Values.galoy.config.notificationTopics | quote }}
+          {{/*
+            mongoMigrationJob, NOT config: .Values.galoy.config is serialised
+            wholesale into the app's custom.yaml by galoy-custom-config-secret.yaml,
+            and the app's configSchema sets additionalProperties:false — so
+            reading this from there meant the only way to supply the value was
+            to crash-loop every app pod at boot. It was therefore never set,
+            the notification-topic migrations threw, migrate-mongo aborted the
+            whole run, and prod applied no migration for five months (ENG-565).
+            This is migration-Job config; the app reads topics off user
+            documents, never from custom.yaml.
+          */}}
+          value: {{ join "," .Values.galoy.mongoMigrationJob.notificationTopics | quote }}
       restartPolicy: Never

--- a/charts/flash/values.yaml
+++ b/charts/flash/values.yaml
@@ -393,6 +393,12 @@ galoy:
     enabled: false
   mongoMigrationJob:
     resources: {}
+    # FCM topics the notification-topic migrations stamp onto every user; they
+    # throw when this is empty, and migrate-mongo then aborts the entire `up`
+    # run. Empty by default so a chart consumer must choose deliberately —
+    # per environment, since a shared list would let one environment's
+    # broadcasts reach another's devices.
+    notificationTopics: []
   ## Kratos
   kratos:
     publicApiUrl: http://flash-kratos-public


### PR DESCRIPTION
Pairs with **lnflash/deployments#196**. Root cause of ENG-565.

## The bug

`galoy-migration-job.yaml` read `NOTIFICATION_TOPICS` from `.Values.galoy.config.notificationTopics`. But `galoy-custom-config-secret.yaml` serialises **that same map wholesale** into the app's `custom.yaml`, and the app's `configSchema` sets `additionalProperties: false`.

So supplying the value the Job required crash-looped every app pod at boot:

```
params: { additionalProperty: 'notificationTopics' }
message: 'must NOT have additional properties'
```

**The value was unsettable.** Which is why it was never set — and why the notification-topic migrations threw, `migrate-mongo` aborted the whole `up` run, and **prod applied no migration between 2026-03-28 and 2026-08-26** while the Job still exited 0.

Confirmed the hard way: deployments#195 set it under `galoy.config` and took TEST down (rolled back to rev 172).

## Fix

Read from `.Values.galoy.mongoMigrationJob.notificationTopics` — a path the Job already owns (it holds `resources`) and which is **not** fed into `custom.yaml`. This is migration-Job config; the app reads topics off user documents, never from `custom.yaml`.

Default remains `[]` so consumers choose deliberately, **per environment** — a shared list would let one environment's broadcasts reach another's devices.

## Verified

- `helm template` renders `value: "EMERGENCY,ATTENTION"` when set, `value: ""` when unset
- all 82 rendered docs parse as YAML
- `helm lint` clean

Related: flash#497 makes the Job exit non-zero when migrations remain pending, so this class of silent failure can't hide again.