### PR TITLE
chore(deps): bump-flash-image-

### DIFF
--- a/charts/flash/Chart.yaml
+++ b/charts/flash/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2 # https://helm.sh/docs/topics/charts/#the-apiversion-field
 name: flash
 description: A Helm chart for the Flash application backend
 type: application
-version: 3.2.74
-appVersion: 0.9.56
+version: 3.2.75
+appVersion: 0.9.57
 dependencies:
   - name: redis
     repository: https://charts.bitnami.com/bitnami

--- a/charts/flash/values.yaml
+++ b/charts/flash/values.yaml
@@ -78,16 +78,16 @@ galoy:
       repository: lnflash/flash-app
       imagePullPolicy: Always
       # digests managed by flash-app pipeline in concourse
-      digest: sha256:0e4096c98edb2548a1bc490c3efbe30ec953ad3797420054d58c53226e672425
-      git_ref: "f933c06"
+      digest: sha256:db85ac27642d926d87098e7fc585d8c6f823ffef75776e06ed1a5142a2bb8186
+      git_ref: "ff8afb2"
     websocket:
       repository: docker.io/lnflash/galoy-app-websocket
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:110173b178e8c6aed5220754c22efa474750794f402e0099daa80f462f00cb91"
+      digest: "sha256:17e711056f1b3c16f437b6aa68e1606c4ef8e2bc0b71263356936b0bb3b5d934"
     mongodbMigrate:
       repository: docker.io/lnflash/galoy-app-migrate
       # digests managed by flash-app pipeline in concourse
-      digest: "sha256:e5f3905fbfd8b7adb9e4d266560cfd209cb27881aff4f418b6f44883058f4722"
+      digest: "sha256:8d0867ebe27676bae66cd345b118ac466376843a920580b5b9a39a62936abc11"
     mongoBackup:
       repository: us.gcr.io/galoy-org/mongo-backup
       # Currently using Galoy's images. To make changes, see /images & /ci in this repo


### PR DESCRIPTION
# Bump flash image

The flash image will be bumped to digest:
```
sha256:db85ac27642d926d87098e7fc585d8c6f823ffef75776e06ed1a5142a2bb8186
```

The mongodbMigrate image will be bumped to digest:
```
sha256:8d0867ebe27676bae66cd345b118ac466376843a920580b5b9a39a62936abc11
```

The websocket image will be bumped to digest:
```
sha256:17e711056f1b3c16f437b6aa68e1606c4ef8e2bc0b71263356936b0bb3b5d934
```

Code diff contained in this image:

https://github.com/lnflash/flash/compare/f933c06...ff8afb2
