### PR TITLE
fix(dev): give the smoketest notification topics, and show job logs on failure

### DIFF
--- a/.github/workflows/dev-smoketest.yaml
+++ b/.github/workflows/dev-smoketest.yaml
@@ -125,7 +125,17 @@ jobs:
           # lives long enough and can never complete here - waiting on
           # `job --all` then times out on them (flaked 2026-07-06).
           for job in $(kubectl -n galoy-dev-galoy get job -o json | jq -r '.items[] | select((.metadata.ownerReferences // []) | map(.kind) | index("CronJob") | not) | .metadata.name'); do
-            kubectl -n galoy-dev-galoy wait --for=condition=complete "job/$job" --timeout=10m
+            # A FAILED job never satisfies condition=complete, so a plain wait
+            # burns the full timeout and reports "timed out waiting for the
+            # condition" with no clue why. Since flash#497 the migrate job can
+            # genuinely fail (that is the point), so surface the logs instead
+            # of leaving the next person a ten-minute mystery.
+            if ! kubectl -n galoy-dev-galoy wait --for=condition=complete "job/$job" --timeout=10m; then
+              echo "::error::job/$job did not complete — logs follow"
+              kubectl -n galoy-dev-galoy logs "job/$job" --tail=80 --all-containers || true
+              kubectl -n galoy-dev-galoy describe "job/$job" | tail -20 || true
+              exit 1
+            fi
           done
           for resource in $(kubectl -n galoy-dev-galoy get deployment,statefulset -o name); do
             kubectl -n galoy-dev-galoy rollout status "$resource" --timeout=10m

--- a/dev/galoy/galoy-values.yml.tmpl
+++ b/dev/galoy/galoy-values.yml.tmpl
@@ -1,4 +1,12 @@
 galoy:
+  mongoMigrationJob:
+    # The notification-topic migrations throw without this, which now fails the
+    # migrate Job outright (flash#497) instead of being swallowed — so the dev
+    # smoketest hangs on `wait --for=condition=complete`. Dev-only values; the
+    # dev- prefix keeps this throwaway cluster off the real alert topics.
+    notificationTopics:
+      - dev-EMERGENCY
+      - dev-ATTENTION
   bria:
     host: bria.external.flash.invalid
   dealer:


### PR DESCRIPTION
**Unblocks charts#276.** Its smoketest fails with `timed out waiting for the condition on jobs/flash-mongodb-migrate-1`.

## Cause

flash#497 makes the migrate job **exit non-zero** when a migration throws, instead of swallowing it (that PR is why prod silently applied no migration for five months — ENG-565). The notification-topic migrations throw without `NOTIFICATION_TOPICS`, and the **dev values never set it**: prod and test got values in deployments#196, dev was missed.

So the job now correctly fails where it previously reported a false green. #276 is the first PR to carry the strict script, which is why it surfaced there.

## Fixes

1. **`dev/galoy/galoy-values.yml.tmpl`** sets `galoy.mongoMigrationJob.notificationTopics` to `[dev-EMERGENCY, dev-ATTENTION]`. The `dev-` prefix keeps the throwaway cluster off the real alert topics — the same separation prod (`EMERGENCY`) and test (`test-`) already have.

2. **The wait step now surfaces the failure.** `--for=condition=complete` is *never* satisfied by a FAILED job, so a genuine failure was indistinguishable from a hang: ten minutes, then "timed out waiting for the condition", no logs. Now it prints the job's logs and `describe` before exiting.

The second fix is the more valuable one. The migrate job **could not fail** before, so nobody needed its logs. Now that it can, the smoketest has to be able to say why.